### PR TITLE
Add syntax highlighting for rdl code examples

### DIFF
--- a/docs/generated_package.rst
+++ b/docs/generated_package.rst
@@ -108,7 +108,7 @@ registers:
 
 This can be described with the following systemRDL code:
 
-.. code-block:: systemRDL
+.. code-block:: systemrdl
 
     addrmap mychip {
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-argparse
+pygments-systemrdl


### PR DESCRIPTION
Looks like you just needed the systemrdl pygments plugin :wink: 