### PR TITLE
Issue #47 - add child getter generators to addrmap/regfile classes

### DIFF
--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -7,6 +7,7 @@ This code was generated from the PeakRDL-python package
 from typing import Tuple
 from typing import Iterable
 from typing import List
+from typing import Union
 
 from ..lib import AddressMap, RegFile, Memory
 from ..lib import RegReadOnly, RegWriteOnly, RegReadWrite, Reg
@@ -165,7 +166,8 @@ class {{get_fully_qualified_type_name(node)}}_cls(RegFile):
         {%- endif %}
     {% endfor %}
 
-    {{ child_getter(node, "get_registers", "Reg", systemrdlRegNode) }}
+    {{ child_getter(node, "get_registers", "Reg",     systemrdlRegNode) }}
+    {{ child_getter(node, "get_regfiles",  "RegFile", systemrdlRegfileNode) }}
 {%- endmacro %}
 
 {%- macro addrmap_class(node) %}
@@ -204,10 +206,11 @@ class {{get_fully_qualified_type_name(node)}}_cls(AddressMap):
     {{ child_getter(node, "get_registers",   "Reg",        systemrdlRegNode) }}
     {{ child_getter(node, "get_memories",    "Memory",     systemrdlMemNode) }}
     {{ child_getter(node, "get_addressmaps", "AddressMap", systemrdlAddrmapNode) }}
+    {{ child_getter(node, "get_regfiles",    "RegFile",    systemrdlRegfileNode) }}
 {%- endmacro %}
 
 {%- macro child_getter(node, getter_name, child_type, child_rdltype) %}
-    def {{getter_name}}(self, unroll=False) -> Iterable[{{child_type}}]:
+    def {{getter_name}}(self, unroll=False) -> Iterable[Union[{{child_type}},Tuple[{{child_type}},...]]]:
         """
         generator that produces all the {{child_type}} children of this node
         """
@@ -215,7 +218,7 @@ class {{get_fully_qualified_type_name(node)}}_cls(AddressMap):
             {%- if isinstance(child_node, child_rdltype) %}
         {% if child_node.is_array -%}
         if unroll:
-            for child in self.{{child_node.inst_name}}:
+            for child in self.{{child_node.inst_name}}: # type: ignore
                 yield child
         else:
             yield self.{{child_node.inst_name}}

--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -8,8 +8,8 @@ from typing import Tuple
 from typing import Iterable
 from typing import List
 
-from ..lib import AddressMap, RegFile
-from ..lib import RegReadOnly, RegWriteOnly, RegReadWrite
+from ..lib import AddressMap, RegFile, Memory
+from ..lib import RegReadOnly, RegWriteOnly, RegReadWrite, Reg
 from ..lib import FieldReadOnly, FieldWriteOnly, FieldReadWrite
 from ..lib import FieldSizeProps, Field
 from ..lib import CallbackSet
@@ -165,6 +165,7 @@ class {{get_fully_qualified_type_name(node)}}_cls(RegFile):
         {%- endif %}
     {% endfor %}
 
+    {{ child_getter(node, "get_registers", "Reg", systemrdlRegNode) }}
 {%- endmacro %}
 
 {%- macro addrmap_class(node) %}
@@ -199,6 +200,33 @@ class {{get_fully_qualified_type_name(node)}}_cls(AddressMap):
         return self.__{{child_node.inst_name}}
             {%- endif %}
         {% endfor %}
+
+    {{ child_getter(node, "get_registers",   "Reg",        systemrdlRegNode) }}
+    {{ child_getter(node, "get_memories",    "Memory",     systemrdlMemNode) }}
+    {{ child_getter(node, "get_addressmaps", "AddressMap", systemrdlAddrmapNode) }}
+{%- endmacro %}
+
+{%- macro child_getter(node, getter_name, child_type, child_rdltype) %}
+    def {{getter_name}}(self, unroll=False) -> Iterable[{{child_type}}]:
+        """
+        generator that produces all the {{child_type}} children of this node
+        """
+        {% for child_node in node.children(unroll=False) -%}
+            {%- if isinstance(child_node, child_rdltype) %}
+        {% if child_node.is_array -%}
+        if unroll:
+            for child in self.{{child_node.inst_name}}:
+                yield child
+        else:
+            yield self.{{child_node.inst_name}}
+        {% else -%}
+        yield self.{{child_node.inst_name}}
+        {%- endif %}
+            {%- endif -%}
+        {% endfor %}
+
+        # Empty generator in case there are no children of this type
+        if False: yield
 {%- endmacro %}
 
 {% if uses_enum %}

--- a/src/peakrdl_python/templates/peakrdl_python/__init__.py
+++ b/src/peakrdl_python/templates/peakrdl_python/__init__.py
@@ -15,6 +15,7 @@ from .base import RegFile
 from .register import RegReadOnly
 from .register import RegWriteOnly
 from .register import RegReadWrite
+from .register import Reg
 
 from .fields import FieldSizeProps
 from .fields import FieldReadOnly
@@ -22,7 +23,7 @@ from .fields import FieldWriteOnly
 from .fields import FieldReadWrite
 from .fields import Field
 
-
 from .memory import MemoryReadOnly
 from .memory import MemoryWriteOnly
 from .memory import MemoryReadWrite
+from .memory import Memory


### PR DESCRIPTION
This adds the generators discussed, with optional unrolling of array children.
It doesn't add any of the other niceties - I'll make separate tickets for those.

I'm aware that everything else is done as properties, but that prevents passing an `unroll` argument.