### PR TITLE
79 add option to not generate tests

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -107,6 +107,8 @@ jobs:
         peakrdl python tests/testcases/basic.rdl -o peakrdl_out/autopep8/ --autoformat
         pytest peakrdl_out/autopep8
 
+        peakrdl python tests/testcases/basic.rdl -o peakrdl_out/no_test/ --skip_test_case_generation
+
     - name: Check Examples
       run: |
         python -m pip install peakrdl

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.3.9"
+__version__ = "0.3.10"

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -32,6 +32,8 @@ class Exporter:
                                 help='use autopep8 on generated code')
         arg_group.add_argument('--user_template_dir', action='store', type=pathlib.Path,
                                help='directory of user templates to override the default ones')
+        arg_group.add_argument('--skip_test_case_generation', action='store_true',
+                            help='skip the generation of the test cases')
 
     def do_export(self, top_node: 'AddrmapNode', options: 'argparse.Namespace') -> None:
         """
@@ -52,5 +54,6 @@ class Exporter:
         peakrdl_exporter.export(
             top_node,
             options.output,
-            autoformatoutputs=options.autoformat
+            autoformatoutputs=options.autoformat,
+            skip_test_case_generation=options.skip_test_case_generation
         )

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -89,7 +89,8 @@ class PythonExporter:
         self.node_type_name = {}
 
     def export(self, node: Node, path: str,
-               autoformatoutputs: bool=True) -> List[str]:
+               autoformatoutputs: bool=True,
+               skip_test_case_generation: bool=False) -> List[str]:
         """
         Generated Python Code and Testbench
 
@@ -99,17 +100,20 @@ class PythonExporter:
             path (str) : Output package path.
             autoformatoutputs (bool) : If set to True the code will be run through autopep8 to
                 clean it up. This can slow down large jobs or mask problems
+            skip_test_case_generation (bool): skip generation the generation of the test cases
 
         Returns:
             List[str] : modules that have been exported:
         """
+        # pylint: disable=too-many-locals
 
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):
             node = node.top
 
         package_path = os.path.join(path, node.inst_name)
-        self._create_empty_package(package_path=package_path)
+        self._create_empty_package(package_path=package_path,
+                                   skip_test_case_generation=skip_test_case_generation)
 
         modules = [node]
 
@@ -169,17 +173,18 @@ class PythonExporter:
                 stream = template.stream(context)
                 stream.dump(module_fqfn, encoding='utf-8')
 
-            template = self.jj_env.get_template("addrmap_tb.py.jinja")
-            module_tb_fqfn = os.path.join(package_path,
-                                          'tests',
-                                          'test_' + block.inst_name + '.py')
-            if autoformatoutputs is True:
-                module_tb_code_str = autopep8.fix_code(template.render(context))
-                with open(module_tb_fqfn, "w", encoding='utf-8') as fid:
-                    fid.write(module_tb_code_str)
-            else:
-                stream = template.stream(context)
-                stream.dump(module_tb_fqfn, encoding='utf-8')
+            if not skip_test_case_generation:
+                template = self.jj_env.get_template("addrmap_tb.py.jinja")
+                module_tb_fqfn = os.path.join(package_path,
+                                              'tests',
+                                              'test_' + block.inst_name + '.py')
+                if autoformatoutputs is True:
+                    module_tb_code_str = autopep8.fix_code(template.render(context))
+                    with open(module_tb_fqfn, "w", encoding='utf-8') as fid:
+                        fid.write(module_tb_code_str)
+                else:
+                    stream = template.stream(context)
+                    stream.dump(module_tb_fqfn, encoding='utf-8')
 
         return [m.inst_name for m in modules]
 
@@ -226,12 +231,14 @@ class PythonExporter:
                 self.node_type_name[child_inst] = cand_type_name
 
     @staticmethod
-    def _create_empty_package(package_path:str) -> None:
+    def _create_empty_package(package_path:str,
+                              skip_test_case_generation: bool) -> None:
         """
         create the directories and __init__.py files associated with the exported package
 
         Args:
             package_path: directory for the package output
+            skip_test_case_generation: skip the generation of the test folders
 
         Returns:
             None
@@ -240,15 +247,17 @@ class PythonExporter:
 
         Path(package_path).mkdir(parents=True, exist_ok=True)
         Path(os.path.join(package_path, 'reg_model')).mkdir(parents=True, exist_ok=True)
-        Path(os.path.join(package_path, 'tests')).mkdir(parents=True, exist_ok=True)
+        if not skip_test_case_generation:
+            Path(os.path.join(package_path, 'tests')).mkdir(parents=True, exist_ok=True)
         Path(os.path.join(package_path, 'lib')).mkdir(parents=True, exist_ok=True)
 
         module_fqfn = os.path.join(package_path, 'reg_model', '__init__.py')
         with open(module_fqfn, 'w', encoding='utf-8') as fid:
             fid.write('pass\n')
-        module_fqfn = os.path.join(package_path, 'tests', '__init__.py')
-        with open(module_fqfn, 'w', encoding='utf-8') as fid:
-            fid.write('pass\n')
+        if not skip_test_case_generation:
+            module_fqfn = os.path.join(package_path, 'tests', '__init__.py')
+            with open(module_fqfn, 'w', encoding='utf-8') as fid:
+                fid.write('pass\n')
         module_fqfn = os.path.join(package_path, '__init__.py')
         with open(module_fqfn, 'w', encoding='utf-8') as fid:
             fid.write('pass\n')

--- a/src/peakrdl_python/peakpython.py
+++ b/src/peakrdl_python/peakpython.py
@@ -56,6 +56,8 @@ def build_command_line_parser() -> argparse.ArgumentParser:
                          help='run a coverage report on the unittests')
     checker.add_argument('--html_coverage_out',
                          help='output director (default: %(default)s)')
+    parser.add_argument('--skip_test_case_generation', action='store_true',
+                        help='skip the generation of the test cases')
 
     return parser
 
@@ -91,7 +93,9 @@ def compile_rdl(infile:str,
     return rdlc.elaborate(top_def_name=top).top
 
 
-def generate(root:Node, outdir:str, autoformatoutputs:bool=True) -> List[str]:
+def generate(root:Node, outdir:str,
+             autoformatoutputs:bool=True,
+             skip_test_case_generation:bool=False) -> List[str]:
     """
     Generate a PeakRDL output package from compiled systemRDL
 
@@ -107,7 +111,8 @@ def generate(root:Node, outdir:str, autoformatoutputs:bool=True) -> List[str]:
     """
     print(f'Info: Generating python for {root.inst_name} in {outdir}')
     modules = PythonExporter().export(root, outdir,
-                                      autoformatoutputs=autoformatoutputs)
+                                      autoformatoutputs=autoformatoutputs,
+                                      skip_test_case_generation=skip_test_case_generation)
 
     return modules
 
@@ -140,6 +145,9 @@ def main_function():
     cli_parser = build_command_line_parser()
     args = cli_parser.parse_args()
 
+    if args.test and args.skip_test_case_generation:
+        raise ValueError('it is not possible to run the tests if the generation has been skipped')
+
     print('***************************************************************')
     print('* Compile the SystemRDL                                       *')
     print('***************************************************************')
@@ -149,7 +157,8 @@ def main_function():
     print('***************************************************************')
     print('* Generate the Python Package                                 *')
     print('***************************************************************')
-    generate(spec, args.outdir, args.autoformat)
+    generate(spec, args.outdir, args.autoformat,
+             skip_test_case_generation=args.skip_test_case_generation)
 
     if args.lint:
         print('***************************************************************')

--- a/src/peakrdl_python/safe_name_utility.py
+++ b/src/peakrdl_python/safe_name_utility.py
@@ -26,7 +26,7 @@ from .templates.peakrdl_python.base import RegFile
 from .templates.peakrdl_python.base import AddressMap
 from .templates.peakrdl_python.base import Base
 
-def _build_class_method_list(peakrld_python_class:Type[Base]) -> list[str]:
+def _build_class_method_list(peakrld_python_class:Type[Base]) -> List[str]:
     return list(filter(lambda x: not x[0] == '_', dir(peakrld_python_class)))
 
 # the lists of methods to avoid for all the classes are pre-built to optimise the time taken


### PR DESCRIPTION
Added an option to skip the generation of the test cases to speed up generation times.

Optimised the `safe_name_utility` module that is used for checking whether a proposed class attribute will clash with existing names by doing the scan of the library class just once with the module is initialised.