### PR TITLE
Update PeakRDL plugin to use base class

### DIFF
--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -5,6 +5,8 @@ refer to the PeakRDL documentation
 from typing import TYPE_CHECKING
 import pathlib
 
+from peakrdl.plugins.exporter import ExporterSubcommandPlugin #pylint: disable=import-error
+
 from .exporter import PythonExporter
 
 if TYPE_CHECKING:
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
     from systemrdl.node import AddrmapNode  # type: ignore
 
 
-class Exporter:
+class Exporter(ExporterSubcommandPlugin):
     """
     PeakRDL export class, see PeakRDL for more details
     """


### PR DESCRIPTION
As you might have seen, I reworked how PeakRDL handles plugins slightly.
Starting in v0.7.0, all importer & exporter plugin descriptor classes now have to be derived off of a base class.
This is something I initially hesitated to do, but after a while found it cumbersome to not have proper class inheritance here.
Unfortunately this kinda breaks compatibility, but hey this is all beta stuff so far anyways and I was bound to change my mind on these things :wink: 

Also, PeakRDL v0.7.0 brings a new "organization-specific" configuration mechanism. See details: https://peakrdl.readthedocs.io/en/latest/configuring.html

This is totally up to you, but now you can move things like the `user_template_dir` to be defined using this mechanism instead of stuffing it into the command-line.
See: https://peakrdl.readthedocs.io/en/latest/for-devs/descriptors.html#peakrdl.plugins.exporter.ExporterSubcommandPlugin.cfg_schema