### PR TITLE
73 split the auto generated test file into one file per addr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
                     ]
                     },
     install_requires=[
-        "systemrdl-compiler>=1.21.0",
+        "systemrdl-compiler>=1.24.0",
         "autopep8",
         "pylint",
         "coverage",

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.6.0.rc1"
+__version__ = "0.6.0"

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.6.0"
+__version__ = "0.6.0.rc1"

--- a/src/peakrdl_python/_node_walkers.py
+++ b/src/peakrdl_python/_node_walkers.py
@@ -1,0 +1,65 @@
+"""
+Node walkers to be used in the generated of the output code
+"""
+from typing import Optional, List, Union
+
+from systemrdl import RDLListener, WalkerAction
+from systemrdl import RegNode, MemNode, FieldNode, AddrmapNode, RegfileNode
+
+
+class AddressMaps(RDLListener):
+    """
+    class intended to be used as part of the walker/listener protocol to find all the desendent
+    address maps
+    """
+    def __init__(self):
+        super().__init__()
+        self.__address_maps: List[AddrmapNode] = []
+
+    def enter_Addrmap(self, node):
+        if not isinstance(node, AddrmapNode):
+            raise ValueError(f'node:{node.inst_name} is not an Address Map')
+        self.__address_maps.append(node)
+        return WalkerAction.Continue
+
+    def __iter__(self):
+        return self.__address_maps.__iter__()
+
+
+class OwnedbyAddressMap(RDLListener):
+    """
+    class intended to be used as part of the walker/listener protocol to find all the items owned
+    by an address map but not the descendents of any address map
+    """
+    def __init__(self):
+        super().__init__()
+
+        self.registers: List[RegNode] = []
+        self.fields: List[RegNode]  = []
+        self.memories: List[RegNode]  = []
+        self.addr_maps: List[AddrmapNode]  = []
+        self.reg_files: List[RegfileNode] = []
+
+    def enter_Reg(self, node: RegNode) -> Optional[WalkerAction]:
+        self.registers.append(node)
+        return WalkerAction.Continue
+
+    def enter_Mem(self, node: MemNode) -> Optional[WalkerAction]:
+        self.memories.append(node)
+        return WalkerAction.Continue
+
+    def enter_Field(self, node: FieldNode) -> Optional[WalkerAction]:
+        self.fields.append(node)
+        return WalkerAction.Continue
+
+    def enter_Addrmap(self, node) -> Optional[WalkerAction]:
+        self.addr_maps.append(node)
+        return WalkerAction.SkipDescendants
+
+    def enter_Regfile(self, node: RegfileNode) -> Optional[WalkerAction]:
+        self.reg_files.append(node)
+        return WalkerAction.Continue
+
+    @property
+    def nodes(self) -> List[Union[RegNode, MemNode, FieldNode, AddrmapNode, RegfileNode]]:
+        return self.addr_maps + self.reg_files + self.memories + self.registers + self.fields

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -248,7 +248,10 @@ class PythonExporter:
                     'get_reg_max_value_hex_string': get_reg_max_value_hex_string,
                     'get_reg_writable_fields': get_reg_writable_fields,
                     'get_reg_readable_fields': get_reg_readable_fields,
+                    'get_memory_max_entry_value_hex_string': get_memory_max_entry_value_hex_string,
                     'get_enum_values': get_enum_values,
+                    'get_array_typecode': get_array_typecode,
+                    'get_memory_width_bytes': get_memory_width_bytes,
                     'asyncoutput': asyncoutput,
                     'uses_enum': uses_enum(block),
                     'version': __version__

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -248,6 +248,7 @@ class PythonExporter:
                     'get_reg_max_value_hex_string': get_reg_max_value_hex_string,
                     'get_reg_writable_fields': get_reg_writable_fields,
                     'get_reg_readable_fields': get_reg_readable_fields,
+                    'get_enum_values': get_enum_values,
                     'asyncoutput': asyncoutput,
                     'uses_enum': uses_enum(block),
                     'version': __version__

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -9,6 +9,7 @@ from glob import glob
 
 import autopep8 # type: ignore
 import jinja2 as jj
+from systemrdl import RDLWalker
 
 from systemrdl.node import RootNode, Node, RegNode, AddrmapNode, RegfileNode # type: ignore
 from systemrdl.node import FieldNode, MemNode, AddressableNode # type: ignore
@@ -27,6 +28,8 @@ from .systemrdl_node_utility_functions import get_reg_readable_fields, get_reg_w
 from .lib import get_array_typecode
 
 from .safe_name_utility import get_python_path_segments, safe_node_name
+
+from ._node_walkers import AddressMaps, OwnedbyAddressMap
 
 from .__about__ import __version__
 
@@ -115,78 +118,141 @@ class PythonExporter:
 
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):
-            node = node.top
+            top_block = node.top
+        else:
+            top_block = node
 
         package_path = os.path.join(path, node.inst_name)
         self._create_empty_package(package_path=package_path,
                                    skip_test_case_generation=skip_test_case_generation)
 
-        modules = [node]
+        self._build_node_type_table(top_block)
 
-        for block in modules:
+        context = {
+            'print': print,
+            'type': type,
+            'top_node': top_block,
+            'systemrdlFieldNode': FieldNode,
+            'systemrdlRegNode': RegNode,
+            'systemrdlRegfileNode': RegfileNode,
+            'systemrdlAddrmapNode': AddrmapNode,
+            'systemrdlMemNode': MemNode,
+            'systemrdlAddressableNode': AddressableNode,
+            'systemrdlSignalNode': SignalNode,
+            'asyncoutput': asyncoutput,
+            'OnWriteType': OnWriteType,
+            'OnReadType': OnReadType,
+            'PropertyReference': PropertyReference,
+            'isinstance': isinstance,
+            'uses_enum' : uses_enum(top_block),
+            'uses_memory' : uses_memory(top_block),
+            'get_fully_qualified_type_name': self._lookup_type_name,
+            'get_array_dim': get_array_dim,
+            'get_dependent_component': get_dependent_component,
+            'get_dependent_enum': self._get_dependent_enum,
+            'get_enum_values': get_enum_values,
+            'get_fully_qualified_enum_type': self._fully_qualified_enum_type,
+            'get_field_bitmask_hex_string': get_field_bitmask_hex_string,
+            'get_field_inv_bitmask_hex_string': get_field_inv_bitmask_hex_string,
+            'get_field_max_value_hex_string': get_field_max_value_hex_string,
+            'get_reg_max_value_hex_string': get_reg_max_value_hex_string,
+            'get_table_block': get_table_block,
+            'get_reg_writable_fields': get_reg_writable_fields,
+            'get_reg_readable_fields': get_reg_readable_fields,
+            'get_memory_max_entry_value_hex_string': get_memory_max_entry_value_hex_string,
+            'get_array_typecode': get_array_typecode,
+            'get_memory_width_bytes': get_memory_width_bytes,
+            'get_field_default_value': get_field_default_value,
+            'raise_template_error' : self._raise_template_error,
+            'get_python_path_segments' : get_python_path_segments,
+            'safe_node_name' : safe_node_name,
+            'version' : __version__
+        }
 
-            self._build_node_type_table(block)
+        context.update(self.user_template_context)
+
+        template = self.jj_env.get_template("addrmap.py.jinja")
+        module_fqfn = os.path.join(package_path,
+                                   'reg_model',
+                                   top_block.inst_name + '.py')
+        if autoformatoutputs is True:
+            module_code_str = autopep8.fix_code(template.render(context))
+            with open(module_fqfn, "w", encoding='utf-8') as fid:
+                fid.write(module_code_str)
+        else:
+            stream = template.stream(context)
+            stream.dump(module_fqfn, encoding='utf-8')
+
+        if not skip_test_case_generation:
+
+            # make the top level base class for all the other test, this is what instantes
+            # the register model
+            template = self.jj_env.get_template("baseclass_tb.py.jinja")
+            module_tb_fqfn = os.path.join(package_path,
+                                          'tests',
+                                          '_' + top_block.inst_name + '_test_base.py')
 
             context = {
-                'print': print,
-                'type': type,
-                'top_node': block,
-                'systemrdlFieldNode': FieldNode,
-                'systemrdlRegNode': RegNode,
-                'systemrdlRegfileNode': RegfileNode,
-                'systemrdlAddrmapNode': AddrmapNode,
-                'systemrdlMemNode': MemNode,
-                'systemrdlAddressableNode': AddressableNode,
-                'systemrdlSignalNode': SignalNode,
+                'top_node': top_block,
                 'asyncoutput': asyncoutput,
-                'OnWriteType': OnWriteType,
-                'OnReadType': OnReadType,
-                'PropertyReference': PropertyReference,
-                'isinstance': isinstance,
-                'uses_enum' : uses_enum(block),
-                'uses_memory' : uses_memory(block),
-                'get_fully_qualified_type_name': self._lookup_type_name,
-                'get_array_dim': get_array_dim,
-                'get_dependent_component': get_dependent_component,
-                'get_dependent_enum': self._get_dependent_enum,
-                'get_enum_values': get_enum_values,
-                'get_fully_qualified_enum_type': self._fully_qualified_enum_type,
-                'get_field_bitmask_hex_string': get_field_bitmask_hex_string,
-                'get_field_inv_bitmask_hex_string': get_field_inv_bitmask_hex_string,
-                'get_field_max_value_hex_string': get_field_max_value_hex_string,
-                'get_reg_max_value_hex_string': get_reg_max_value_hex_string,
-                'get_table_block': get_table_block,
-                'get_reg_writable_fields': get_reg_writable_fields,
-                'get_reg_readable_fields': get_reg_readable_fields,
-                'get_memory_max_entry_value_hex_string': get_memory_max_entry_value_hex_string,
-                'get_array_typecode': get_array_typecode,
-                'get_memory_width_bytes': get_memory_width_bytes,
-                'get_field_default_value': get_field_default_value,
-                'raise_template_error' : self._raise_template_error,
-                'get_python_path_segments' : get_python_path_segments,
-                'safe_node_name' : safe_node_name,
-                'version' : __version__
+                'version': __version__
             }
 
-            context.update(self.user_template_context)
-
-            template = self.jj_env.get_template("addrmap.py.jinja")
-            module_fqfn = os.path.join(package_path,
-                                       'reg_model',
-                                       block.inst_name + '.py')
             if autoformatoutputs is True:
-                module_code_str = autopep8.fix_code(template.render(context))
-                with open(module_fqfn, "w", encoding='utf-8') as fid:
-                    fid.write(module_code_str)
+                module_tb_code_str = autopep8.fix_code(template.render(context))
+                with open(module_tb_fqfn, "w", encoding='utf-8') as fid:
+                    fid.write(module_tb_code_str)
             else:
                 stream = template.stream(context)
-                stream.dump(module_fqfn, encoding='utf-8')
+                stream.dump(module_tb_fqfn, encoding='utf-8')
 
-            if not skip_test_case_generation:
-                template = self.jj_env.get_template("addrmap_tb.py.jinja")
+            # make the tests themselves
+            template = self.jj_env.get_template("addrmap_tb.py.jinja")
+
+            blocks = AddressMaps()
+            # running the walker populated the blocks with all the address maps in within the
+            # top block, including the top_block itself
+            RDLWalker(unroll=True).walk(top_block, blocks, skip_top=False)
+
+            for block in blocks:
+                owned_elements = OwnedbyAddressMap()
+                # running the walker populated the blocks with all the address maps in within the
+                # top block, including the top_block itself
+                RDLWalker(unroll=True).walk(block, owned_elements, skip_top=True)
+
+                fq_block_name = '_'.join(block.get_path_segments(array_suffix = '_{index:d}_'))
+
                 module_tb_fqfn = os.path.join(package_path,
                                               'tests',
-                                              'test_' + block.inst_name + '.py')
+                                              'test_' + fq_block_name + '.py')
+
+                context = {
+                    'top_node': top_block,
+                    'block' : block,
+                    'fq_block_name' : fq_block_name,
+                    'owned_elements': owned_elements,
+                    'systemrdlFieldNode': FieldNode,
+                    'systemrdlSignalNode': SignalNode,
+                    'systemrdlRegNode': RegNode,
+                    'systemrdlMemNode': MemNode,
+                    'systemrdlRegfileNode': RegfileNode,
+                    'systemrdlAddrmapNode': AddrmapNode,
+                    'isinstance': isinstance,
+                    'get_python_path_segments': get_python_path_segments,
+                    'safe_node_name': safe_node_name,
+                    'uses_memory': (len(owned_elements.memories) > 0),
+                    'get_field_bitmask_hex_string': get_field_bitmask_hex_string,
+                    'get_field_inv_bitmask_hex_string': get_field_inv_bitmask_hex_string,
+                    'get_field_max_value_hex_string': get_field_max_value_hex_string,
+                    'get_field_default_value': get_field_default_value,
+                    'get_reg_max_value_hex_string': get_reg_max_value_hex_string,
+                    'get_reg_writable_fields': get_reg_writable_fields,
+                    'get_reg_readable_fields': get_reg_readable_fields,
+                    'asyncoutput': asyncoutput,
+                    'uses_enum': uses_enum(block),
+                    'version': __version__
+                }
+
                 if autoformatoutputs is True:
                     module_tb_code_str = autopep8.fix_code(template.render(context))
                     with open(module_tb_fqfn, "w", encoding='utf-8') as fid:
@@ -195,7 +261,7 @@ class PythonExporter:
                     stream = template.stream(context)
                     stream.dump(module_tb_fqfn, encoding='utf-8')
 
-        return [m.inst_name for m in modules]
+        return top_block.inst_name
 
     def _lookup_type_name(self, node: Node) -> str:
         """

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -9,7 +9,7 @@ from glob import glob
 
 import autopep8 # type: ignore
 import jinja2 as jj
-from systemrdl import RDLWalker
+from systemrdl import RDLWalker # type: ignore
 
 from systemrdl.node import RootNode, Node, RegNode, AddrmapNode, RegfileNode # type: ignore
 from systemrdl.node import FieldNode, MemNode, AddressableNode # type: ignore

--- a/src/peakrdl_python/templates/addrmap_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_tb.py.jinja
@@ -42,105 +42,19 @@ from ..lib import Memory
 from ..lib import Field
 from ..lib import Reg
 
-# dummy functions to support the test cases, note that these are not used as
-# they get patched
-{% if asyncoutput %}async {% endif %}def read_addr_space(addr: int, width: int, accesswidth: int) -> int:
-    assert isinstance(addr, int)
-    assert isinstance(width, int)
-    assert isinstance(accesswidth, int)
-    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
-    return 0
+from ._{{top_node.inst_name}}_test_base import {{top_node.type_name}}_TestCase, {{top_node.type_name}}_TestCase_BlockAccess
+from ._{{top_node.inst_name}}_test_base import __name__ as base_name
 
-{% if asyncoutput %}async {% endif %}def write_addr_space(addr: int, width: int, accesswidth: int,  data: int) -> None:
-    assert isinstance(addr, int)
-    assert isinstance(width, int)
-    assert isinstance(accesswidth, int)
-    assert isinstance(data, int)
-    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
-
-{% if asyncoutput %}async {% endif %}def read_callback(addr: int, width: int, accesswidth: int) -> int:
-    return {% if asyncoutput %}await {% endif %}read_addr_space(addr=addr, width=width, accesswidth=accesswidth)
-
-{% if asyncoutput %}async {%endif %}def read_block_addr_space(addr: int, width: int, accesswidth: int, length:int) -> Array:
-    assert isinstance(addr, int)
-    assert isinstance(width, int)
-    assert isinstance(accesswidth, int)
-    assert isinstance(length, int)
-
-    if width == 32:
-        typecode = 'L'
-    elif width == 64:
-        typecode = 'Q'
-    elif width == 16:
-        typecode = 'I'
-    elif width == 8:
-        typecode = 'B'
-    else:
-        raise ValueError('unhandled memory width')
-
-    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
-    return Array(typecode, [0 for x in range(length)])
-
-{% if asyncoutput %}async {%endif %}def read_block_callback(addr: int, width: int, accesswidth: int, length: int) -> Array:
-    return {% if asyncoutput %}await {% endif %}read_block_addr_space(addr=addr, width=width, accesswidth=accesswidth, length=length)
-
-{% if asyncoutput %}async {%endif %}def write_callback(addr: int, width: int, accesswidth: int,  data: int) -> None:
-    {% if asyncoutput %}await {% endif %}write_addr_space(addr=addr, width=width, accesswidth=accesswidth, data=data)
-
-{% if asyncoutput %}async {%endif %}def write_block_addr_space(addr: int, width: int, accesswidth: int,  data: Array) -> None:
-    assert isinstance(addr, int)
-    assert isinstance(width, int)
-    assert isinstance(accesswidth, int)
-    assert isinstance(data, Array)
-    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
-
-{% if asyncoutput %}async {%endif %}def write_block_callback(addr: int, width: int, accesswidth: int,  data: Array) -> None:
-    {% if asyncoutput %}await {% endif %}write_block_addr_space(addr=addr, width=width, accesswidth=accesswidth, data=data)
-
-{% if asyncoutput %}
-if sys.version_info < (3, 8):
-    TestCaseBase = asynctest.TestCase
-else:
-    TestCaseBase = unittest.IsolatedAsyncioTestCase
-{% else %}
-TestCaseBase = unittest.TestCase
-{% endif %}
-
-class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,misc]
-
-    def setUp(self) -> None:
-        self.dut = {{top_node.type_name}}_cls({% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}(read_callback=read_callback,
-                                                          write_callback=write_callback))
-
-    @staticmethod
-    def _reverse_bits(value: int, number_bits: int) -> int:
-        """
-
-        Args:
-            value: value to reverse
-            number_bits: number of bits used in the value
-
-        Returns:
-            reversed valued
-        """
-        result = 0
-        for i in range(number_bits):
-            if (value >> i) & 1:
-                result |= 1 << (number_bits - 1 - i)
-        return result
+class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: ignore[valid-type,misc]
 
     def test_inst_name(self)  -> None:
         """
         Walk the address map and check the inst name has been correctly populated
         """
-        {% for node in top_node.descendants(unroll=True) -%}
-        {% if isinstance(node, systemrdlSignalNode) %}
-        # doing nothing with signal node: {{node.inst_name}}
-        {% else %}
+        {% for node in owned_elements.nodes -%}
         with self.subTest(msg='node: {{'.'.join(node.get_path_segments())}}'):
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.inst_name, '{{node.get_path_segments()[-1]}}') # type: ignore[union-attr]
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.full_inst_name, '{{'.'.join(node.get_path_segments())}}')  # type: ignore[union-attr]
-        {% endif %}
         {% endfor %}
 
     def test_register_properties(self)  -> None:
@@ -148,13 +62,11 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         Walk the address map and check the address, size and accesswidth of every register is
         correct
         """
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.address, {{node.absolute_address}}) # type: ignore[union-attr]
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.width, {{node.size * 8}}) # type: ignore[union-attr]
             {% if 'accesswidth' in node.list_properties() -%}self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth, {{node.get_property('accesswidth')}}){%- else -%} self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth, self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth){%- endif %} # type: ignore[union-attr]
-            {%- endif %}
         {%- endfor %}
 
     def test_memory_properties(self)  -> None:
@@ -163,8 +75,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         correct
         """
         mut: Memory
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlMemNode) %}
+        {% for node in owned_elements.memories -%}
         with self.subTest(msg='memory: {{'.'.join(node.get_path_segments())}}'):
             mut = self.dut.{{'.'.join(get_python_path_segments(node))}} # type: ignore[union-attr,assignment]
             self.assertIsInstance(mut, Memory)
@@ -172,7 +83,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
             self.assertEqual(mut.width, {{node.get_property('memwidth')}})
             self.assertEqual(mut.entries, {{node.get_property('mementries')}})
             {% if 'accesswidth' in node.list_properties() -%}self.assertEqual(mut.accesswidth, {{node.get_property('accesswidth')}}){%- else -%}self.assertEqual(mut.accesswidth, mut.accesswidth){%- endif %}
-            {%- endif %}
         {%- endfor %}
 
     def test_field_properties(self)  -> None:
@@ -182,8 +92,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         - that where default values are provided they are applied correctly
         """
         fut:Field
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlFieldNode) %}
+        {% for node in owned_elements.fields -%}
         with self.subTest(msg='field: {{'.'.join(node.get_path_segments())}}'):
             # test properties of field: {{'.'.join(node.get_path_segments())}}
             fut = self.dut.{{'.'.join(get_python_path_segments(node))}} # type: ignore[union-attr]
@@ -207,22 +116,20 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
             self.assertEqual(fut.default,{{get_field_default_value(node)}})
                 {% endif %}
             self.assertEqual(fut.is_volatile,{{node.is_hw_writable}})
-            {%- endif -%}
-        {%- endfor %}
+        {% endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_register_read_and_write(self) -> None:
         """
         Walk the register map and check every register can be read and written to correctly
         """
         rut: Reg
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         # test access operations (read and/or write) to register:
         # {{'.'.join(node.get_path_segments())}}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
             rut=self.dut.{{'.'.join(get_python_path_segments(node))}} # type: ignore[union-attr,assignment]
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                patch(__name__ + '.' + 'read_addr_space', return_value=1) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                patch(base_name + '.read_addr_space', return_value=1) as read_callback_mock:
 
                 {% if node.has_sw_readable -%}
                 {% if asyncoutput %}
@@ -323,7 +230,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
 
                 # check the read has not been called in the write test
                 read_callback_mock.assert_not_called()
-            {%- endif %}
         {%- endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_int_field_read_and_write(self) -> None:
@@ -331,16 +237,15 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         Check the ability to read and write to integer (non-eumn) fields
         """
         fut:Field
-    {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlFieldNode) %}
+        {% for node in owned_elements.fields -%}
         {%- if 'encode' not in node.list_properties() %}
 
         # test access operations (read and/or write) to field:
         # {{'.'.join(node.get_path_segments())}}
         with self.subTest(msg='field: {{'.'.join(node.get_path_segments())}}'):
             fut = self.dut.{{'.'.join(get_python_path_segments(node))}} # type: ignore[union-attr]
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock,\
-                patch(__name__ + '.' + 'read_addr_space', return_value=0) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock,\
+                patch(base_name + '.read_addr_space', return_value=0) as read_callback_mock:
 
                 {% if node.is_sw_readable %}
                 {% if asyncoutput %}
@@ -462,7 +367,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 {%- endif %}
 
         {%- endif %}
-        {%- endif %}
     {%- endfor %}
 
     {% if uses_enum %}
@@ -470,15 +374,14 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         """
         Check the ability to read and write to enum fields
         """
-    {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlFieldNode) %}
+    {% for node in owned_elements.fields -%}
         {%- if 'encode' in node.list_properties() %}
 
         # test access operations (read and/or write) to field:
         # {{'.'.join(node.get_path_segments())}}
         with self.subTest(msg='field: {{'.'.join(node.get_path_segments())}}'):
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock,\
-                patch(__name__ + '.' + 'read_addr_space', return_value=0) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock,\
+                patch(base_name + '.read_addr_space', return_value=0) as read_callback_mock:
 
                 {% if node.is_sw_readable %}
                 # read back test
@@ -578,7 +481,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 {% endif %}
 
         {%- endif %}
-        {%- endif %}
     {%- endfor %}
     {%- endif %}
 
@@ -587,8 +489,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         Walk the register map and check every register read_fields method
         """
         reference_read_fields: Dict[str, Union[bool, IntEnum, int]]
-        {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         {% if node.has_sw_readable %}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
             # test read_fields to register:
@@ -616,8 +517,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
             {{ raise_template_error('unexpected type') }}
                 {% endif %}
             {% endfor %}
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                 patch(__name__ + '.' + 'read_addr_space', return_value=rand_reg_value) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                 patch(base_name + '.read_addr_space', return_value=rand_reg_value) as read_callback_mock:
                 # the read_fields method gets a dictionary back
                 # from the object with all the read back field
                 # values
@@ -638,7 +539,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 write_callback_mock.assert_not_called()
 
         {%- endif %}
-        {%- endif %}
         {%- endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_register_read_context_manager(self) -> None:
@@ -646,8 +546,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         Walk the register map and check every register read_fields method
         """
         reference_read_fields: Dict[str, Union[bool, IntEnum, int]]
-        {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         {% if node.has_sw_readable %}
         # test context manager to register:
         # {{'.'.join(node.get_path_segments())}}
@@ -673,8 +572,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 # skipping {{field.inst_name}}
                 {% endif %}
             {% endfor %}
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                 patch(__name__ + '.' + 'read_addr_space', return_value=rand_reg_value) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                 patch(base_name + '.read_addr_space', return_value=rand_reg_value) as read_callback_mock:
 
                 # first read the fields using the "normal" method, then compare the result to reading
                 # via the context manager
@@ -706,7 +605,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 write_callback_mock.assert_not_called()
 
         {%- endif %}
-        {%- endif %}
         {%- endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_register_write_context_manager(self) -> None:
@@ -715,8 +613,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         """
         rut:Reg{% if asyncoutput %}Async{% endif %}ReadWrite
         {% if asyncoutput %}async {% endif %}def write_field_cominbinations(reg: Reg{% if asyncoutput %}Async{% endif %}ReadWrite, writable_fields:List[str]) -> None:
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                patch(__name__ + '.' + 'read_addr_space', return_value=0) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                patch(base_name + '.read_addr_space', return_value=0) as read_callback_mock:
                 for num_parm in range(1, len(writable_fields) + 1):
                     for fields_to_write in combinations(writable_fields, num_parm):
                         field_values = {}
@@ -781,8 +679,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                         write_callback_mock.reset_mock()
                         read_callback_mock.reset_mock()
 
-        {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         {% if node.has_sw_writable and node.has_sw_readable %}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
             rut = self.dut.{{'.'.join(get_python_path_segments(node))}} # type: ignore[union-attr,assignment]
@@ -793,7 +690,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                                                    '{{ safe_node_name(field) }}' {%- if not loop.last -%},{%- endif %}
                                                    {% endfor -%} ])
         {%- endif %}
-        {%- endif %}
         {%- endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_register_write_fields(self) -> None:
@@ -803,8 +699,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         rut:Reg{% if asyncoutput %}Async{% endif %}ReadWrite
         rand_enum_value:IntEnum
         {% if asyncoutput %}async {% endif %}def write_field_cominbinations(reg: Reg{% if asyncoutput %}Async{% endif %}ReadWrite, writable_fields:List[str]) -> None:
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                patch(__name__ + '.' + 'read_addr_space', return_value=0) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                patch(base_name + '.read_addr_space', return_value=0) as read_callback_mock:
                 for num_parm in range(1, len(writable_fields) + 1):
                     for fields_to_write in combinations(writable_fields, num_parm):
                         kwargs = {}
@@ -837,8 +733,7 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                         read_callback_mock.reset_mock()
 
 
-        {%- for node in top_node.descendants(unroll=True) -%}
-        {%- if isinstance(node, systemrdlRegNode) %}
+        {% for node in owned_elements.registers -%}
         {% if node.has_sw_writable %}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
             # test read_fields to register:
@@ -867,8 +762,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
             {%- endif  %}
             expected_value = ( expected_value & {{get_field_inv_bitmask_hex_string(field)}} ) | (rand_field_value << {{ field.low }})
             {% endfor %}
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                patch(__name__ + '.' + 'read_addr_space', return_value=0) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                patch(base_name + '.read_addr_space', return_value=0) as read_callback_mock:
                 {% if asyncoutput %}await {% endif %}self.dut.{{'.'.join(get_python_path_segments(node))}}.write_fields(**kwargs)  # type: ignore[union-attr]
                 write_callback_mock.assert_called_once_with(
                                     addr={{node.absolute_address}},
@@ -883,7 +778,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
 
 
         {%- endif %}
-        {%- endif %}
         {%- endfor %}
 
     {% if uses_memory %}
@@ -891,14 +785,13 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         """
         Walk the register map and check every register can be read and written to correctly
         """
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlMemNode) %}
+        {% for node in owned_elements.memories -%}
 
         # test access operations (read and/or write) to register:
         # {{'.'.join(node.get_path_segments())}}
         with self.subTest(msg='memory: {{'.'.join(node.get_path_segments())}}'):
-            with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock, \
-                patch(__name__ + '.' + 'read_addr_space', return_value=1) as read_callback_mock:
+            with patch(base_name + '.write_addr_space') as write_callback_mock, \
+                patch(base_name + '.read_addr_space', return_value=1) as read_callback_mock:
 
                 {% if node.is_sw_readable -%}
                 # checks single unit accesses at the first entry, the last entry and a random entry in
@@ -972,7 +865,6 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
 
                 {%- endif %}
 
-        {%- endif %}
         {%- endfor %}
     {%- endif %}
 
@@ -984,16 +876,12 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         every be a attribute name
 
         """
-        {%- for node in top_node.descendants(unroll=True) %}
-        {% if isinstance(node, systemrdlSignalNode) %}
-        # doing nothing with signal node: {{node.inst_name}}
-        {% else %}
+        {% for node in owned_elements.nodes -%}
         with self.subTest(msg='node: {{'.'.join(node.get_path_segments())}}'):
             with self.assertRaises(AttributeError):
                 # this line is trying to set an illegal value so by definition should fail the type
                 # checks
                 self.dut.{{'.'.join(get_python_path_segments(node))}}.cppkbrgmgeloagvfgjjeiiushygirh = 1 # type: ignore[attr-defined,union-attr]
-        {% endif %}
         {%- endfor %}
 
     {% macro check_readable_register_iterators(node) %}
@@ -1092,8 +980,8 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
         {% endif %}
         expected_sections : List[Union[AddressMap, RegFile]]
 
-        {%- for node in top_node.descendants(unroll=True) %}
-            {%- if isinstance(node, systemrdlRegNode) %}
+        # test all the registers
+        {% for node in owned_elements.registers -%}
         with self.subTest(msg='register: {{'.'.join(node.get_path_segments())}}'):
                 {# a register can only have fields beneath it #}
                 {% if node.has_sw_writable %}
@@ -1122,7 +1010,10 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
             # register should not have readable_fields attribute
             self.assertFalse(hasattr(self.dut.{{'.'.join(get_python_path_segments(node))}}, 'readable_fields')) # type: ignore[union-attr]
                     {% endif %}
-            {%- elif isinstance(node, systemrdlMemNode) %}
+        {% endfor %}
+        # test all the memories
+        {% for node in owned_elements.memories -%}
+
         with self.subTest(msg='memory: {{'.'.join(node.get_path_segments())}}'):
                     {% if node.is_sw_writable %}
                         {{ check_writable_register_iterators(node) | indent }}
@@ -1134,58 +1025,55 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                     {% else %}
             self.assertFalse(hasattr(self.dut.{{'.'.join(get_python_path_segments(node))}}, 'get_readable_registers')) # type: ignore[union-attr]
                     {% endif %}
-            {%- elif isinstance(node, systemrdlAddrmapNode) %}
+        {% endfor %}
+        # test all the address maps
+        {% for node in owned_elements.addr_maps -%}
         with self.subTest(msg='addrmap: {{'.'.join(node.get_path_segments())}}'):
             {{ check_readable_register_iterators(node) | indent }}
             {{ check_writable_register_iterators(node) | indent}}
             {{ check_section_iterators(node) | indent }}
             {{ check_memory_iterators(node) | indent}}
-            {%- elif isinstance(node, systemrdlRegfileNode) %}
+        {% endfor %}
+        # test all the register files
+        {% for node in owned_elements.reg_files -%}
         with self.subTest(msg='regfile: {{'.'.join(node.get_path_segments())}}'):
             {{ check_readable_register_iterators(node) | indent }}
             {{ check_writable_register_iterators(node)  | indent}}
             {{ check_section_iterators(node) | indent }}
             self.assertFalse(hasattr(self.dut.{{'.'.join(get_python_path_segments(node))}}, 'get_memories')) # type: ignore[union-attr]
-            {% endif %}
-        {%- endfor %}
+        {% endfor %}
 
     def test_name_map(self) -> None:
         """
         Check that the function for getting a node by its original systemRDL name works
         """
-        {% for node in top_node.descendants(unroll=True) -%}
-        {% if not isinstance(node, (systemrdlFieldNode, systemrdlSignalNode)) %}
+        {% for node in owned_elements.nodes -%}
         {% for child_node in node.children(unroll=False) %}
         {% if not isinstance(child_node, systemrdlSignalNode) %}
         self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.get_child_by_system_rdl_name('{{child_node.inst_name}}').inst_name, '{{child_node.inst_name}}')  # type: ignore[union-attr]
         {% endif %}
         {% endfor %}
-        {% endif %}
         {% endfor %}
 
-class {{top_node.type_name}}_TestCase_BlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
-
-    def setUp(self) -> None:
-        self.dut = {{top_node.type_name}}_cls({% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}(read_callback=read_callback,
-                                                          write_callback=write_callback,
-                                                          read_block_callback=read_block_callback,
-                                                          write_block_callback=write_block_callback))
+class {{fq_block_name}}_block_access({{top_node.type_name}}_TestCase_BlockAccess): # type: ignore[valid-type,misc]
+    """
+    tests for all the block access methods
+    """
 
     {% if uses_memory %}
     {% if asyncoutput %}async {% endif %}def test_memory_read_and_write(self) -> None:
         """
         Walk the register map and check every register can be read and written to correctly
         """
-        {%- for node in top_node.descendants(unroll=True) -%}
-            {%- if isinstance(node, systemrdlMemNode) %}
+        {% for node in owned_elements.memories -%}
 
         # test access operations (read and/or write) to register:
         # {{'.'.join(node.get_path_segments())}}
-        with patch(__name__ + '.' + 'write_addr_space') as write_callback_mock,\
-                            patch(__name__ + '.' + 'read_addr_space', return_value=1) as read_callback_mock, \
-                            patch(__name__ + '.' + 'read_block_addr_space',
+        with patch(base_name + '.write_addr_space') as write_callback_mock,\
+                            patch(base_name + '.read_addr_space', return_value=1) as read_callback_mock, \
+                            patch(base_name + '.read_block_addr_space',
                                   return_value=Array('{{get_array_typecode(node.get_property('memwidth'))}}', [0])) as read_block_callback_mock , \
-                            patch(__name__ + '.' + 'write_block_addr_space') as write_block_callback_mock:
+                            patch(base_name + '.write_block_addr_space') as write_block_callback_mock:
 
             {% if node.is_sw_readable -%}
             # checks single unit accesses at the first entry, the last entry and a random entry in
@@ -1260,7 +1148,6 @@ class {{top_node.type_name}}_TestCase_BlockAccess(TestCaseBase): # type: ignore[
 
             {%- endif %}
 
-        {%- endif %}
         {%- endfor %}
     {%- endif %}
 

--- a/src/peakrdl_python/templates/addrmap_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_tb.py.jinja
@@ -20,12 +20,6 @@ import math
 from enum import IntEnum
 
 from ..lib import RegisterWriteVerifyError
-{% if asyncoutput %}
-from ..lib import AsyncCallbackSet
-{% else %}
-from ..lib import NormalCallbackSet
-{% endif %}
-
 
 from ..reg_model.{{top_node.type_name}} import {{top_node.type_name}}_cls
 {% if asyncoutput %}
@@ -67,7 +61,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: 
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.address, {{node.absolute_address}}) # type: ignore[union-attr]
             self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.width, {{node.size * 8}}) # type: ignore[union-attr]
             {% if 'accesswidth' in node.list_properties() -%}self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth, {{node.get_property('accesswidth')}}){%- else -%} self.assertEqual(self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth, self.dut.{{'.'.join(get_python_path_segments(node))}}.accesswidth){%- endif %} # type: ignore[union-attr]
-        {%- endfor %}
+        {% endfor %}
 
     def test_memory_properties(self)  -> None:
         """
@@ -83,7 +77,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: 
             self.assertEqual(mut.width, {{node.get_property('memwidth')}})
             self.assertEqual(mut.entries, {{node.get_property('mementries')}})
             {% if 'accesswidth' in node.list_properties() -%}self.assertEqual(mut.accesswidth, {{node.get_property('accesswidth')}}){%- else -%}self.assertEqual(mut.accesswidth, mut.accesswidth){%- endif %}
-        {%- endfor %}
+        {% endfor %}
 
     def test_field_properties(self)  -> None:
         """
@@ -230,7 +224,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: 
 
                 # check the read has not been called in the write test
                 read_callback_mock.assert_not_called()
-        {%- endfor %}
+        {% endfor %}
 
     {% if asyncoutput %}async {% endif %}def test_int_field_read_and_write(self) -> None:
         """
@@ -882,7 +876,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: 
                 # this line is trying to set an illegal value so by definition should fail the type
                 # checks
                 self.dut.{{'.'.join(get_python_path_segments(node))}}.cppkbrgmgeloagvfgjjeiiushygirh = 1 # type: ignore[attr-defined,union-attr]
-        {%- endfor %}
+        {% endfor %}
 
     {% macro check_readable_register_iterators(node) %}
         {# check the unrolled case first #}

--- a/src/peakrdl_python/templates/baseclass_tb.py.jinja
+++ b/src/peakrdl_python/templates/baseclass_tb.py.jinja
@@ -1,0 +1,129 @@
+{% include "header_tb.py.jinja" with context %}
+from array import array as Array
+{% if asyncoutput %}
+import sys
+import asyncio
+if sys.version_info < (3, 8):
+    import asynctest  # type: ignore[import]
+else:
+    import unittest
+{% else %}
+import unittest
+{% endif %}
+
+
+from ..lib import RegisterWriteVerifyError
+{% if asyncoutput %}
+from ..lib import AsyncCallbackSet
+{% else %}
+from ..lib import NormalCallbackSet
+{% endif %}
+
+
+from ..reg_model.{{top_node.type_name}} import {{top_node.type_name}}_cls
+
+
+# dummy functions to support the test cases, note that these are not used as
+# they get patched
+{% if asyncoutput %}async {% endif %}def read_addr_space(addr: int, width: int, accesswidth: int) -> int:
+    assert isinstance(addr, int)
+    assert isinstance(width, int)
+    assert isinstance(accesswidth, int)
+    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
+    return 0
+
+{% if asyncoutput %}async {% endif %}def write_addr_space(addr: int, width: int, accesswidth: int,  data: int) -> None:
+    assert isinstance(addr, int)
+    assert isinstance(width, int)
+    assert isinstance(accesswidth, int)
+    assert isinstance(data, int)
+    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
+
+{% if asyncoutput %}async {% endif %}def read_callback(addr: int, width: int, accesswidth: int) -> int:
+    return {% if asyncoutput %}await {% endif %}read_addr_space(addr=addr, width=width, accesswidth=accesswidth)
+
+{% if asyncoutput %}async {%endif %}def read_block_addr_space(addr: int, width: int, accesswidth: int, length:int) -> Array:
+    assert isinstance(addr, int)
+    assert isinstance(width, int)
+    assert isinstance(accesswidth, int)
+    assert isinstance(length, int)
+
+    if width == 32:
+        typecode = 'L'
+    elif width == 64:
+        typecode = 'Q'
+    elif width == 16:
+        typecode = 'I'
+    elif width == 8:
+        typecode = 'B'
+    else:
+        raise ValueError('unhandled memory width')
+
+    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
+    return Array(typecode, [0 for x in range(length)])
+
+{% if asyncoutput %}async {%endif %}def read_block_callback(addr: int, width: int, accesswidth: int, length: int) -> Array:
+    return {% if asyncoutput %}await {% endif %}read_block_addr_space(addr=addr, width=width, accesswidth=accesswidth, length=length)
+
+{% if asyncoutput %}async {%endif %}def write_callback(addr: int, width: int, accesswidth: int,  data: int) -> None:
+    {% if asyncoutput %}await {% endif %}write_addr_space(addr=addr, width=width, accesswidth=accesswidth, data=data)
+
+{% if asyncoutput %}async {%endif %}def write_block_addr_space(addr: int, width: int, accesswidth: int,  data: Array) -> None:
+    assert isinstance(addr, int)
+    assert isinstance(width, int)
+    assert isinstance(accesswidth, int)
+    assert isinstance(data, Array)
+    {% if asyncoutput %}await asyncio.sleep(1) {% endif %}
+
+{% if asyncoutput %}async {%endif %}def write_block_callback(addr: int, width: int, accesswidth: int,  data: Array) -> None:
+    {% if asyncoutput %}await {% endif %}write_block_addr_space(addr=addr, width=width, accesswidth=accesswidth, data=data)
+
+{% if asyncoutput %}
+if sys.version_info < (3, 8):
+    TestCaseBase = asynctest.TestCase
+else:
+    TestCaseBase = unittest.IsolatedAsyncioTestCase
+{% else %}
+TestCaseBase = unittest.TestCase
+{% endif %}
+
+class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,misc]
+
+    def setUp(self) -> None:
+        self.dut = {{top_node.type_name}}_cls({% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}(read_callback=read_callback,
+                                                          write_callback=write_callback))
+
+    @staticmethod
+    def _reverse_bits(value: int, number_bits: int) -> int:
+        """
+
+        Args:
+            value: value to reverse
+            number_bits: number of bits used in the value
+
+        Returns:
+            reversed valued
+        """
+        result = 0
+        for i in range(number_bits):
+            if (value >> i) & 1:
+                result |= 1 << (number_bits - 1 - i)
+        return result
+
+class {{top_node.type_name}}_TestCase_BlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
+
+    def setUp(self) -> None:
+        self.dut = {{top_node.type_name}}_cls({% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}(read_callback=read_callback,
+                                                          write_callback=write_callback,
+                                                          read_block_callback=read_block_callback,
+                                                          write_block_callback=write_block_callback))
+
+
+
+
+if __name__ == '__main__':
+    pass
+
+
+
+

--- a/tests/testcases/addr_map.rdl
+++ b/tests/testcases/addr_map.rdl
@@ -29,7 +29,7 @@ addrmap child_addr_map_type_c {
 };
 
 addrmap addr_map {
-
+    regtype_a top_reg;
     child_addr_map_type_a child_a;
     child_addr_map_type_b child_b[2];
     child_addr_map_type_c child_c;

--- a/tests/testcases/addr_map.rdl
+++ b/tests/testcases/addr_map.rdl
@@ -1,23 +1,25 @@
 
-addrmap child_addr_map_type_a {
-    reg {
+reg regtype_a {
         default sw = rw;
         default hw = r;
         field {} basicfield_a[31:0];
-    } basicreg_a;
+    };
+
+addrmap child_addr_map_type_a {
+    regtype_a  basicreg_a;
 };
 
 addrmap child_addr_map_type_b {
-    reg {
-        default sw = rw;
-        default hw = r;
-        field {} basicfield_a[15:0];
-    } basicreg_a;
+    regtype_a basicreg_a;
+
+    regfile {
+        regtype_a basicreg_a;
+    } regfile_a[2];
 };
 
 addrmap child_addr_map_type_c {
 
-    child_addr_map_type_b child_c_b;
+    child_addr_map_type_b child_b[2];
 
     reg {
         default sw = rw;
@@ -29,6 +31,6 @@ addrmap child_addr_map_type_c {
 addrmap addr_map {
 
     child_addr_map_type_a child_a;
-    child_addr_map_type_a child_b[2];
-    child_addr_map_type_b child_c;
+    child_addr_map_type_b child_b[2];
+    child_addr_map_type_c child_c;
 };


### PR DESCRIPTION
Change the test case generation logic to only test items owned by each register map. Each addressmap instance goes into a separate file.