### PR TITLE
Removal of integrated autopep8 support

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -97,8 +97,6 @@ jobs:
         peakrdl python tests/testcases/basic.rdl -o peakrdl_out/raw/
         peakrdl python tests/testcases/simple.xml tests/testcases/multifile.rdl -o peakrdl_out/raw
         python -m unittest discover -s peakrdl_out/raw
-        peakrdl python tests/testcases/basic.rdl -o peakrdl_out/autopep8/ --autoformat
-        python -m unittest discover -s peakrdl_out/autopep8
         peakrdl python tests/testcases/basic.rdl -o peakrdl_out/raw_async/ --async
         python -m unittest discover -s peakrdl_out/raw_async
 

--- a/docs/generated_package.rst
+++ b/docs/generated_package.rst
@@ -441,3 +441,14 @@ field from the example above
 .. literalinclude :: ../example/overridden_names/over_ridden_names.py
    :language: python
 
+
+Autoformating
+=============
+
+Previous versions of peakrdl-python included the option to run an autoformatter to clean up the
+generated code. This had two issues:
+
+* It created maintenance issues when the autoformatter changed
+* The choice of autoformatter is an individual one, rather than force an autoformatter on people
+  it is better to let people choose their own.
+

--- a/generate_testcases.py
+++ b/generate_testcases.py
@@ -46,7 +46,7 @@ def compile_rdl(infile: str,
 
 
 def generate(root: Node, outdir: str,
-             autoformatoutputs: bool = True, asyncoutput: bool = False,
+             asyncoutput: bool = False,
              skip_test_case_generation: bool = False) -> List[str]:
     """
     Generate a PeakRDL output package from compiled systemRDL
@@ -65,7 +65,6 @@ def generate(root: Node, outdir: str,
     """
     print(f'Info: Generating python for {root.inst_name} in {outdir}')
     modules = PythonExporter().export(root, outdir, # type: ignore[no-untyped-call]
-                                      autoformatoutputs=autoformatoutputs,
                                       asyncoutput=asyncoutput,
                                       skip_test_case_generation=skip_test_case_generation)
 
@@ -96,12 +95,9 @@ if __name__ == '__main__':
         else:
             root = compile_rdl(rdl_file)
 
-        for autoformatoutputs, asyncoutput, folder_name in [(False, False, 'raw'),
-                                                            (True, False, 'autopep8'),
-                                                            (False, True, 'raw_async'),
-                                                            (True, True, 'autopep8_async')]:
+        for asyncoutput, folder_name in [(False, 'raw'),
+                                         (True, 'raw_async')]:
             _ = generate(root, os.path.join('testcase_output', folder_name),
-                            autoformatoutputs=False,
                             asyncoutput=asyncoutput)
 
             module_fqfn = os.path.join('testcase_output', folder_name, '__init__.py')

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     python_requires='>=3.7, <4',
     install_requires=[
         "systemrdl-compiler>=1.24.0",
-        "autopep8",
         "jinja2",
         "asynctest;python_version<'3.8'",
         "peakrdl-ipxact"

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -41,8 +41,6 @@ class Exporter(ExporterSubcommandPlugin):
         """
         arg_group.add_argument('--async', action='store_true', dest='is_async',
                                help='define accesses to register model as asynchronous')
-        arg_group.add_argument('--autoformat', action='store_true',
-                                help='use autopep8 on generated code')
         arg_group.add_argument('--skip_test_case_generation', action='store_true',
                             help='skip the generation of the test cases')
 
@@ -65,6 +63,5 @@ class Exporter(ExporterSubcommandPlugin):
             top_node,
             options.output,
             options.is_async,
-            autoformatoutputs=options.autoformat,
             skip_test_case_generation=options.skip_test_case_generation
         )

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -2,7 +2,6 @@
 Main Classes for the PeakRDL Python
 """
 import os
-import warnings
 from pathlib import Path
 from shutil import copyfile
 from typing import List, NoReturn, Iterable, Tuple
@@ -246,13 +245,8 @@ class PythonExporter:
                     'version': __version__
                 }
 
-                if autoformatoutputs is True:
-                    module_tb_code_str = autopep8.fix_code(template.render(context))
-                    with open(module_tb_fqfn, "w", encoding='utf-8') as fid:
-                        fid.write(module_tb_code_str)
-                else:
-                    stream = template.stream(context)
-                    stream.dump(module_tb_fqfn, encoding='utf-8')
+                stream = template.stream(context)
+                stream.dump(module_tb_fqfn, encoding='utf-8')
 
         return top_block.inst_name
 

--- a/src/peakrdl_python/peakpython.py
+++ b/src/peakrdl_python/peakpython.py
@@ -46,12 +46,8 @@ def build_command_line_parser() -> argparse.ArgumentParser:
     parser.add_argument('--user_template_dir', action='store', type=pathlib.Path,
                            help='directory of user templates to override the default ones')
     checker = parser.add_argument_group('post-generate checks')
-    checker.add_argument('--lint', action='store_true',
-                         help='run pylint on the generated python (support removed at 0.6.1)')
     checker.add_argument('--test', action='store_true',
                          help='run unittests for the created')
-    checker.add_argument('--coverage', action='store_true',
-                         help='run a coverage report on the unittests (support removed at 0.6.1)')
     parser.add_argument('--skip_test_case_generation', action='store_true',
                         help='skip the generation of the test cases')
 
@@ -90,6 +86,7 @@ def compile_rdl(infile:str,
 
 
 def generate(root:Node, outdir:str,
+             asyncoutput:bool=False,
              skip_test_case_generation:bool=False) -> List[str]:
     """
     Generate a PeakRDL output package from compiled systemRDL
@@ -136,19 +133,15 @@ def main_function() -> None:
     print('***************************************************************')
     print('* Generate the Python Package                                 *')
     print('***************************************************************')
-    generate(spec, args.outdir, autoformatoutputs=args.autoformat,
+    generate(spec, args.outdir,
              skip_test_case_generation=args.skip_test_case_generation,
              asyncoutput=args.asyncoutput)
-    if args.lint:
-        raise NotImplementedError('Support for running linting checks was removed at 0.6.1, '
-                                  'pylint can be run seperatly on the generated code if needed')
+
     if args.test:
         print('***************************************************************')
         print('* Unit Test Run                                               *')
         print('***************************************************************')
-        if args.coverage:
-            raise NotImplementedError('Support for geneating a coverage report was removed at '
-                                      '0.6.1, this can be done separately if needed')
+
         tests = unittest.TestLoader().discover(
             start_dir=os.path.join(args.outdir, spec.inst_name, 'tests'),
             top_level_dir=args.outdir)

--- a/src/peakrdl_python/peakpython.py
+++ b/src/peakrdl_python/peakpython.py
@@ -39,8 +39,6 @@ def build_command_line_parser() -> argparse.ArgumentParser:
                              'global addrmap)')
     parser.add_argument('--verbose', '-v', action='count', default=0,
                         help='set logging verbosity')
-    parser.add_argument('--autoformat', action='store_true',
-                        help='use autopep8 on generated code')
     parser.add_argument('--async', action='store_true',
                         help='builds the register model using the async callbacks')
     parser.add_argument('--ipxact', dest='ipxact', nargs='*',
@@ -92,7 +90,6 @@ def compile_rdl(infile:str,
 
 
 def generate(root:Node, outdir:str,
-             autoformatoutputs:bool=True,asyncoutput:bool=False,
              skip_test_case_generation:bool=False) -> List[str]:
     """
     Generate a PeakRDL output package from compiled systemRDL
@@ -100,8 +97,6 @@ def generate(root:Node, outdir:str,
     Args:
         root: node in the systemRDL from which the code should be generated
         outdir: directory to store the result in
-        autoformatoutputs: If set to True the code will be run through autopep8 to
-                clean it up. This can slow down large jobs or mask problems
         asyncoutput: If set to True the code build a register model with async operations to
                 access the harware layer
 
@@ -111,7 +106,6 @@ def generate(root:Node, outdir:str,
     """
     print(f'Info: Generating python for {root.inst_name} in {outdir}')
     modules = PythonExporter().export(root, outdir, # type: ignore[no-untyped-call]
-                                      autoformatoutputs=autoformatoutputs,
                                       asyncoutput=asyncoutput,
                                       skip_test_case_generation=skip_test_case_generation)
 


### PR DESCRIPTION
This was mainly to simplify peakrdl python but also due to a bug in autopep8 that was breaking the build