### PR TITLE
Added Black to the CI pipeline

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -93,9 +93,9 @@ jobs:
     - name: Test Autoformating
       run: |
         python -m pip install black
-        cp test_case_output autoformatted_test_case_output -f
+        cp testcase_output autoformatted_testcase_output -r
         black autoformatted_test_case_output --line-length 120
-        python -m unittest discover -s autoformatted_test_case_output
+        python -m unittest discover -s autoformatted_testcase_output
 
     - name: Run PeakRDL Case
       run: |

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -94,7 +94,7 @@ jobs:
       run: |
         python -m pip install black
         cp testcase_output autoformatted_testcase_output -r
-        black autoformatted_test_case_output --line-length 120
+        black autoformatted_testcase_output --line-length 120
         python -m unittest discover -s autoformatted_testcase_output
 
     - name: Run PeakRDL Case

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -93,7 +93,7 @@ jobs:
     - name: Test Autoformating
       run: |
         python -m pip install black
-        cp ./test_case_output ./autoformatted_test_case_output
+        cp test_case_output autoformatted_test_case_output -f
         black autoformatted_test_case_output --line-length 120
         python -m unittest discover -s autoformatted_test_case_output
 

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -90,6 +90,13 @@ jobs:
 
         python -m unittest discover -s testcase_output
 
+    - name: Test Autoformating
+      run: |
+        python -m pip install black
+        cp ./test_case_output ./autoformatted_test_case_output
+        black autoformatted_test_case_output --line-length 120
+        python -m unittest discover -s autoformatted_test_case_output
+
     - name: Run PeakRDL Case
       run: |
         python -m pip install peakrdl

--- a/docs/generated_package.rst
+++ b/docs/generated_package.rst
@@ -445,10 +445,15 @@ field from the example above
 Autoformating
 =============
 
-Previous versions of peakrdl-python included the option to run an autoformatter to clean up the
-generated code. This had two issues:
+The generated code is not perfect it often has lots of spare black lines, over time this will
+improve but the quickest way to resolve these issue is to include an autoformatter
+post-generation. Previous versions of peakrdl-python included the option to run an autoformatter
+to clean up the generated code. This had two issues:
 
 * It created maintenance issues when the autoformatter changed
 * The choice of autoformatter is an individual one, rather than force an autoformatter on people
   it is better to let people choose their own.
+
+peakrdl-python uses the Black `Black <https://pypi.org/project/black/L>`_ in the CI tests to check
+that the generated code is compatible with an autoformatter.
 


### PR DESCRIPTION
The autoformatter was removed from peakrdl-python see #88 

Added the Black auto formatter to the CI process and improved the documentation around the use of the autoformatter