### PR TITLE
Clean up existing python files

### DIFF
--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -1,4 +1,4 @@
 """
 Variables that describes the PeakRDL Python Package
 """
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -43,6 +43,15 @@ class Exporter(ExporterSubcommandPlugin):
                                help='define accesses to register model as asynchronous')
         arg_group.add_argument('--skip_test_case_generation', action='store_true',
                                help='skip the generation of the test cases')
+        arg_group.add_argument('--suppress_cleanup', action='store_true', dest='suppress_cleanup',
+                               help='by default peakrdl_python deletes all existing python .py '
+                                    'files found in the directory where the package will be'
+                                    ' generated. This is normally useful if the user is '
+                                    'generating over the top of an existing package and prevents '
+                                    'problems when the strucutre of the register map changes. '
+                                    'However, if additional python files are added by the user '
+                                    '(not recommended) this cleanup will need to be suppressed '
+                                    'and managed by the user')
 
     def do_export(self, top_node: 'AddrmapNode', options: 'argparse.Namespace') -> None:
         """
@@ -57,11 +66,12 @@ class Exporter(ExporterSubcommandPlugin):
         """
         templates = self.cfg['user_template_dir']
         peakrdl_exporter = \
-            PythonExporter(user_template_dir=templates) # type: ignore[no-untyped-call]
+            PythonExporter(user_template_dir=templates)  # type: ignore[no-untyped-call]
 
         peakrdl_exporter.export(
             top_node,
             options.output,
             options.is_async,
-            skip_test_case_generation=options.skip_test_case_generation
+            skip_test_case_generation=options.skip_test_case_generation,
+            delete_existing_package_content=not options.suppress_cleanup
         )

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -47,6 +47,9 @@ class _PythonPackage:
 
     @property
     def path(self) -> Path:
+        """
+        path of the package
+        """
         return self._path
 
     def child_package(self, name: str) -> '_PythonPackage':


### PR DESCRIPTION
Add new feature to clean up any existing python files in the generated directory path. 

Also took the opportunity to remove a lot of the path management with string in favour of using the more modern pathlib.