### PR TITLE
Context manager fixes

### DIFF
--- a/docs/api_components.rst
+++ b/docs/api_components.rst
@@ -65,7 +65,7 @@ Memories
     :inherited-members:
 
 Registers
-^^^^^^^^^
+=========
 
 .. autoclass:: peakrdl_python.lib.register.RegReadOnly
     :members:
@@ -93,6 +93,7 @@ Registers
 
 Register Fields
 ^^^^^^^^^^^^^^^
+A register will always have fields within it
 
 .. autoclass:: peakrdl_python.lib.fields.FieldReadOnly
     :members:

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -17,4 +17,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Variables that describes the peakrdl-python Package
 """
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/peakrdl_python/lib/async_register.py
+++ b/src/peakrdl_python/lib/async_register.py
@@ -409,10 +409,8 @@ class RegAsyncReadWrite(RegAsyncReadOnly, RegAsyncWriteOnly, ABC):
                                                    f'after writing {data:X}')
 
     async def read(self) -> int:
-        """Asynchronously read value from the register
-
-        Returns:
-            The value from register
+        """
+        Asynchronously read value from the register
         """
         if self.__in_read_write_context_manager:
             # pylint: disable=duplicate-code
@@ -599,7 +597,8 @@ class AsyncRegArray(BaseRegArray, ABC):
             width: Width of the register in bits
             accesswidth: Minimum access width of the register in bits
 
-        Returns: cache entry
+        Returns:
+            cache entry
 
         """
         if not isinstance(width, int):
@@ -681,8 +680,6 @@ class AsyncRegArray(BaseRegArray, ABC):
         Args:
             verify (bool): very the write with a read afterwards
             skip_write (bool): skip the write back at the end
-
-        Returns:
 
         """
         self.__register_address_array = \

--- a/src/peakrdl_python/lib/register.py
+++ b/src/peakrdl_python/lib/register.py
@@ -94,7 +94,8 @@ class BaseReg(Node, ABC):
 
     @property
     def max_value(self) -> int:
-        """maximum unsigned integer value that can be stored in the register
+        """
+        maximum unsigned integer value that can be stored in the register
 
         For example:
 
@@ -122,9 +123,6 @@ class BaseReg(Node, ABC):
     def width(self) -> int:
         """
         The width of the register in bits, this uses the `regwidth` systemRDL property
-
-        Returns: register width
-
         """
         return self.__width
 
@@ -132,8 +130,6 @@ class BaseReg(Node, ABC):
     def accesswidth(self) -> int:
         """
         The access width of the register in bits, this uses the `accesswidth` systemRDL property
-
-        Returns: register access width
         """
         return self.__accesswidth
 
@@ -243,9 +239,6 @@ class BaseRegArray(NodeArray[BaseRegArrayElementType], ABC):
     def width(self) -> int:
         """
         The width of the register in bits, this uses the `regwidth` systemRDL property
-
-        Returns: register width
-
         """
         return self.__width
 
@@ -253,8 +246,6 @@ class BaseRegArray(NodeArray[BaseRegArrayElementType], ABC):
     def accesswidth(self) -> int:
         """
         The access width of the register in bits, this uses the `accesswidth` systemRDL property
-
-        Returns: register access width
         """
         return self.__accesswidth
 
@@ -431,7 +422,8 @@ class RegArray(BaseRegArray, ABC):
             width: Width of the register in bits
             accesswidth: Minimum access width of the register in bits
 
-        Returns: cache entry
+        Returns:
+            cache entry
 
         """
         if not isinstance(width, int):
@@ -513,9 +505,6 @@ class RegArray(BaseRegArray, ABC):
         Args:
             verify (bool): very the write with a read afterwards
             skip_write (bool): skip the write back at the end
-
-        Returns:
-
         """
         self.__register_address_array = \
             [self.address + (i * (self.width >> 3)) for i in range(self.__number_cache_entries)]
@@ -601,11 +590,8 @@ class RegReadOnly(Reg, ABC):
             self.__in_context_manager = False
 
     def read(self) -> int:
-        """Read value from the register
-
-        Returns:
-            The value from register
-
+        """
+        Read value from the register
         """
         if self.__in_context_manager:
             return self.__register_state
@@ -784,8 +770,6 @@ class RegReadWrite(RegReadOnly, RegWriteOnly, ABC):
             verify (bool): very the write with a read afterwards
             skip_write (bool): skip the write back at the end
 
-        Returns:
-
         """
         if self.__in_read_context_manager:
             raise RuntimeError('using the `single_read_modify_write` context manager within the '
@@ -859,10 +843,8 @@ class RegReadWrite(RegReadOnly, RegWriteOnly, ABC):
                                                    f'after writing {data:X}')
 
     def read(self) -> int:
-        """Read value from the register
-
-        Returns:
-            The value from register
+        """
+        Read value from the register
         """
         if self.__in_read_write_context_manager:
             if self.__register_state is None:
@@ -1005,12 +987,6 @@ class RegWriteOnlyArray(RegArray, ABC):
         """
         Context manager to allow multiple field reads/write to be done with a single set of
         field operations
-
-        Args:
-
-
-        Returns:
-
         """
         with self._cached_access(verify=False, skip_write=False,
                                   skip_initial_read=True) as reg_array:
@@ -1067,9 +1043,6 @@ class RegReadWriteArray(RegArray, ABC):
         Args:
             verify (bool): very the write with a read afterwards
             skip_write (bool): skip the write back at the end
-
-        Returns:
-
         """
         with self._cached_access(verify=verify, skip_write=skip_write,
                                  skip_initial_read=False) as reg_array:

--- a/src/peakrdl_python/lib/register.py
+++ b/src/peakrdl_python/lib/register.py
@@ -143,7 +143,6 @@ class BaseReg(Node, ABC):
         """
         return self.__width >> 3
 
-
     @property
     @abstractmethod
     def _is_readable(self) -> bool:
@@ -153,6 +152,7 @@ class BaseReg(Node, ABC):
     @abstractmethod
     def _is_writeable(self) -> bool:
         ...
+
 
 class Reg(BaseReg, ABC):
     """
@@ -266,7 +266,6 @@ class BaseRegArray(NodeArray[BaseRegArrayElementType], ABC):
             width=self.width,
             accesswidth=self.accesswidth,
             parent=self)
-
 
     def _sub_instance(self, elements: Dict[Tuple[int, ...], BaseRegArrayElementType]) ->\
             NodeArray[BaseRegArrayElementType]:
@@ -472,8 +471,6 @@ class RegArray(BaseRegArray, ABC):
                                                               width=width,
                                                               accesswidth=accesswidth)]
 
-
-
     def __cache_write(self, addr: int, width: int, accesswidth: int, data: int) -> None:
         """
         Used to replace the normal callbacks with those that access the cache
@@ -495,12 +492,10 @@ class RegArray(BaseRegArray, ABC):
                                                        width=width,
                                                        accesswidth=accesswidth)] = data
 
-
     @property
     def __cache_callbacks(self) -> NormalCallbackSet:
         return NormalCallbackSet(read_callback=self.__cache_read,
                                  write_callback=self.__cache_write)
-
 
     @property
     def __number_cache_entries(self) -> int:
@@ -508,7 +503,7 @@ class RegArray(BaseRegArray, ABC):
 
     @contextmanager
     def _cached_access(self, verify: bool = False, skip_write: bool = False,
-                                   skip_initial_read: bool = False) -> \
+                       skip_initial_read: bool = False) -> \
             Generator[Self, None, None]:
         """
         Context manager to allow multiple field reads/write to be done with a single set of
@@ -548,6 +543,7 @@ class RegArray(BaseRegArray, ABC):
         # This cast is OK because the type was checked in the __init__
         # pylint: disable-next=protected-access
         return cast(NormalCallbackSet, self.parent._callbacks)
+
 
 class RegReadOnly(Reg, ABC):
     """
@@ -872,8 +868,10 @@ class RegReadWrite(RegReadOnly, RegWriteOnly, ABC):
         # pylint: disable=duplicate-code
         return True
 
+
 ReadableRegister = Union[RegReadOnly, RegReadWrite]
 WritableRegister = Union[RegWriteOnly, RegReadWrite]
+
 
 class RegReadOnlyArray(RegArray, ABC):
     """
@@ -931,6 +929,7 @@ class RegReadOnlyArray(RegArray, ABC):
     def _is_writeable(self) -> bool:
         # pylint: disable=duplicate-code
         return False
+
 
 class RegWriteOnlyArray(RegArray, ABC):
     """
@@ -1018,7 +1017,6 @@ class RegReadWriteArray(RegArray, ABC):
                          parent=parent, address=address, width=width, accesswidth=accesswidth,
                          stride=stride, dimensions=dimensions, elements=elements)
 
-
     # pylint: enable=too-many-arguments,duplicate-code
 
     @contextmanager
@@ -1036,7 +1034,7 @@ class RegReadWriteArray(RegArray, ABC):
 
         """
         with self._cached_access(verify=verify, skip_write=skip_write,
-                                  skip_initial_read=False) as reg_array:
+                                 skip_initial_read=False) as reg_array:
             yield reg_array
 
     @property

--- a/tests/unit_tests/simple_components.py
+++ b/tests/unit_tests/simple_components.py
@@ -9,7 +9,7 @@ import logging
 from array import array as Array
 
 # pylint: disable-next=unused-wildcard-import, wildcard-import
-from src.peakrdl_python.lib import *
+from peakrdl_python.lib import *
 
 # pylint: disable=logging-not-lazy,logging-fstring-interpolation
 

--- a/tests/unit_tests/simple_components.py
+++ b/tests/unit_tests/simple_components.py
@@ -9,7 +9,7 @@ import logging
 from array import array as Array
 
 # pylint: disable-next=unused-wildcard-import, wildcard-import
-from peakrdl_python.lib import *
+from src.peakrdl_python.lib import *
 
 # pylint: disable=logging-not-lazy,logging-fstring-interpolation
 

--- a/tests/unit_tests/test_reg.py
+++ b/tests/unit_tests/test_reg.py
@@ -306,3 +306,205 @@ class TestReadWrite(RegTestBase):
                                                width=self.dut.width,
                                                accesswidth=self.dut.accesswidth)
             write_patch.assert_not_called()
+
+    def test_context_manager_read_modify_write_check_writeback(self) -> None:
+        """
+        Check the write back has occurred, this happens by default even if nothing has changed in
+        the register
+        """
+
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read_modify_write() as reg:
+                _ = reg.field.read()
+                _ = reg.field.read()
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth, data=0)
+
+        # check the `skip_write` works as expected, this will however raise an deprecation warning
+        # and the feature will be removed at some point in the future
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read_modify_write(skip_write=True) as reg:
+                _ = reg.field.read()
+                _ = reg.field.read()
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+        # check that a write within the `skip_write` works still does not result in a write
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read_modify_write(skip_write=True) as reg:
+                self.assertEqual(reg.field.read(), False)
+                self.assertEqual(reg.field.read(), False)
+                reg.field.write(True)
+                self.assertEqual(reg.field.read(), True)
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+        # attempting to use the `single_read` inside the `single_read_modify_write` context
+        # should cause an exception
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read_modify_write() as reg:
+                _ = reg.field.read()
+                with self.assertRaises(RuntimeError):
+                    with reg.single_read() as alt_reg:
+                        _ = alt_reg.field.read()
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_called_once_with(addr=0,
+                                                width=self.dut.width,
+                                                accesswidth=self.dut.accesswidth, data=0)
+
+        # check the context manager cleans itself up properly even if an exception occurs within
+        # the context
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+            with self.assertRaises(TypeError):
+                with self.dut.single_read_modify_write() as reg:
+                    _ = reg.field.read()
+                    reg.field.write(1.1)
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            read_patch.reset_mock()
+            write_patch.assert_not_called()
+
+            # make sure it has not been left in a bad internal state
+            _ = reg.field.read()
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+
+    def test_read_fields(self) -> None:
+        """
+        Check the read fields methods reads the fields
+        """
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            result = self.dut.read_fields()
+
+            self.assertDictEqual(result, {'field': False})
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+
+    def test_context_manager_read(self) -> None:
+        """
+        Check the write back has occurred, this happens by default even if nothing has changed in
+        the register
+        """
+
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read() as reg:
+                _ = reg.field.read()
+                _ = reg.field.read()
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+        # attempting a write in the single read context manager should raise an exception
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read() as reg:
+                _ = reg.field.read()
+                with self.assertRaises(RuntimeError):
+                    reg.field.write(True)
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+        # attempting to use the `single_read_modify_write` inside the `single_read` context
+        # should cause an exception
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.dut.single_read() as reg:
+                _ = reg.field.read()
+                with self.assertRaises(RuntimeError):
+                    with reg.single_read_modify_write() as alt_reg:
+                        _ = alt_reg.field.read()
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            write_patch.assert_not_called()
+
+        # an exception within the `single_read` context must not leave the register in a bad
+        # state
+        with patch.object(self.callbacks, 'read_callback',
+                          side_effect=self.read_addr_space) as read_patch, \
+                patch.object(self.callbacks, 'write_callback',
+                             side_effect=self.write_addr_space) as write_patch:
+
+            with self.assertRaises(ZeroDivisionError):
+                with self.dut.single_read() as reg:
+                    _ = reg.field.read()
+                    _ = reg.field.read()
+                    # the following line is deliberately intended to cause an exception
+                    _ = 10 / 0
+
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            read_patch.reset_mock()
+            write_patch.assert_not_called()
+
+            self.dut.read()
+            read_patch.assert_called_once_with(addr=0,
+                                               width=self.dut.width,
+                                               accesswidth=self.dut.accesswidth)
+            read_patch.reset_mock()
+
+            self.dut.field.write(True)
+            write_patch.assert_called_once_with(addr=0,
+                                                width=self.dut.width,
+                                                accesswidth=self.dut.accesswidth, data=1)


### PR DESCRIPTION
Fix an issue with exceptions in context manager resulting in the register classes being left in a bad state which has been resolved.

Also includes the following minor fixes:
- protection against mixing context manager operations
- documentation improvement
- deprecation warning for future removal of `skip_write` (see #135 )