### PR TITLE
Fix for excessive positional arguments

### DIFF
--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -17,4 +17,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Variables that describes the peakrdl-python Package
 """
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -109,9 +109,9 @@ class Exporter(ExporterSubcommandPlugin):
                                user_template_context=user_template_context)
 
         peakrdl_exporter.export(
-            top_node,
-            options.output,
-            options.is_async,
+            node=top_node,
+            path=options.output,
+            asyncoutput=options.is_async,
             skip_test_case_generation=options.skip_test_case_generation,
             delete_existing_package_content=not options.suppress_cleanup,
             legacy_block_access=options.legacy_block_access,

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -290,7 +290,8 @@ class PythonExporter:
             stream = template.stream(template_context)
             stream.dump(fp)
 
-    def __export_reg_model(self,  # pylint: disable=too-many-arguments
+    # pylint: disable-next=too-many-arguments
+    def __export_reg_model(self, *,
                            top_block: AddrmapNode,
                            package: _Package,
                            skip_lib_copy: bool,
@@ -359,7 +360,7 @@ class PythonExporter:
                                      target_name=top_block.inst_name + '.py',
                                      template_context=context)
 
-    def __export_simulator(self,
+    def __export_simulator(self, *,
                            top_block: AddrmapNode,
                            package: _Package,
                            skip_lib_copy: bool,
@@ -384,7 +385,7 @@ class PythonExporter:
                                      target_name=top_block.inst_name + '.py',
                                      template_context=context)
 
-    def __export_example(self,
+    def __export_example(self, *,
                          top_block: AddrmapNode,
                          package: _Package,
                          skip_lib_copy: bool,
@@ -409,7 +410,7 @@ class PythonExporter:
                                      target_name='example.py',
                                      template_context=context)
 
-    def __export_base_tests(self,
+    def __export_base_tests(self, *,
                             top_block: AddrmapNode,
                             package: _Package,
                             skip_lib_copy: bool,
@@ -446,7 +447,8 @@ class PythonExporter:
                                      target_name='_' + top_block.inst_name + '_sim_test_base.py',
                                      template_context=context)
 
-    def __export_tests(self,  # pylint: disable=too-many-arguments
+    # pylint: disable-next=too-many-arguments
+    def __export_tests(self, *,
                        top_block: AddrmapNode,
                        package: _Package,
                        skip_lib_copy: bool,
@@ -566,7 +568,8 @@ class PythonExporter:
                     raise RuntimeError('It is not permitted to expose a property name used to'
                                        ' build the peakrdl-python wrappers: ' + reserved_name)
 
-    def export(self, node: Node, path: str,  # pylint: disable=too-many-arguments
+    # pylint: disable-next=too-many-arguments
+    def export(self, node: Node, path: str, *,
                asyncoutput: bool = False,
                skip_test_case_generation: bool = False,
                delete_existing_package_content: bool = True,

--- a/src/peakrdl_python/lib/async_memory.py
+++ b/src/peakrdl_python/lib/async_memory.py
@@ -366,7 +366,7 @@ class _MemoryAsyncWriteOnly(AsyncMemory, ABC):
     __slots__: List[str] = []
 
     # pylint: disable=too-many-arguments
-    def __init__(self,
+    def __init__(self, *,
                  address: int,
                  width: int,
                  accesswidth: int,

--- a/src/peakrdl_python/lib/fields.py
+++ b/src/peakrdl_python/lib/fields.py
@@ -44,7 +44,8 @@ class FieldSizeProps:
     """
     __slots__ = ['__msb', '__lsb', '__width', '__high', '__low']
 
-    def __init__(self, width: int, msb: int, lsb: int, high: int, low: int): #pylint: disable=too-many-arguments
+    # pylint: disable-next=too-many-arguments
+    def __init__(self, *, width: int, msb: int, lsb: int, high: int, low: int):
         self.__width = width
         self.__msb = msb
         self.__lsb = lsb

--- a/src/peakrdl_python/lib/memory.py
+++ b/src/peakrdl_python/lib/memory.py
@@ -231,8 +231,8 @@ class _MemoryReadOnly(Memory, ABC):
 
     __slots__: List[str] = []
 
-    # pylint: disable=too-many-arguments
-    def __init__(self,
+    # pylint: disable-next=too-many-arguments
+    def __init__(self, *,
                  address: int,
                  width: int,
                  accesswidth: int,
@@ -500,8 +500,8 @@ class _MemoryWriteOnly(Memory, ABC):
     """
     __slots__: List[str] = []
 
-    # pylint: disable=too-many-arguments
-    def __init__(self,
+    # pylint: disable-next=too-many-arguments
+    def __init__(self, *,
                  address: int,
                  width: int,
                  accesswidth: int,

--- a/tests/unit_tests/simple_components.py
+++ b/tests/unit_tests/simple_components.py
@@ -25,7 +25,7 @@ class ReadOnlyRegisterToTest(RegReadOnly):
         __slots__: List[str] = []
 
     # pylint: disable=duplicate-code,too-many-arguments
-    def __init__(self,
+    def __init__(self, *,
                  address: int,
                  accesswidth:int,
                  width:int,
@@ -89,6 +89,7 @@ class ReadOnlyRegisterToTest(RegReadOnly):
             'field': 'field',
         }
 
+
 class WriteOnlyRegisterToTest(RegWriteOnly):
     """
     Class to represent a register in the register model
@@ -102,7 +103,7 @@ class WriteOnlyRegisterToTest(RegWriteOnly):
         """
         __slots__: List[str] = []
 
-    def __init__(self,
+    def __init__(self, *,
                  address: int,
                  accesswidth: int,
                  width: int,
@@ -169,6 +170,7 @@ class WriteOnlyRegisterToTest(RegWriteOnly):
             'field': 'field',
         }
 
+
 class ReadWriteRegisterToTest(RegReadWrite):
     """
     Class to represent a register in the register model
@@ -182,7 +184,7 @@ class ReadWriteRegisterToTest(RegReadWrite):
         """
         __slots__: List[str] = []
 
-    def __init__(self,
+    def __init__(self, *,
                  address: int,
                  accesswidth: int,
                  width: int,
@@ -256,6 +258,7 @@ class ReadWriteRegisterToTest(RegReadWrite):
             'field': 'field',
         }
 
+
 class ReadOnlyRegisterArrayToTest(RegReadOnlyArray):
     """
     Class to represent a register array in the register model
@@ -266,6 +269,7 @@ class ReadOnlyRegisterArrayToTest(RegReadOnlyArray):
     def _element_datatype(self) -> Type[Node]:
         return ReadOnlyRegisterToTest
 
+
 class WriteOnlyRegisterArrayToTest(RegWriteOnlyArray):
     """
     Class to represent a register array in the register model
@@ -275,6 +279,7 @@ class WriteOnlyRegisterArrayToTest(RegWriteOnlyArray):
     @property
     def _element_datatype(self) -> Type[Node]:
         return WriteOnlyRegisterToTest
+
 
 class ReadWriteRegisterArrayToTest(RegReadWriteArray):
     """

--- a/tests/unit_tests/test_array_indexing.py
+++ b/tests/unit_tests/test_array_indexing.py
@@ -53,7 +53,6 @@ class ArrayBase(CallBackTestWrapper, ABC):
         address based on array index
         """
 
-
     def setUp(self) -> None:
 
         class DUTWrapper(AddressMap):
@@ -62,14 +61,13 @@ class ArrayBase(CallBackTestWrapper, ABC):
             """
 
             # pylint: disable=too-many-arguments,duplicate-code
-            def __init__(self,
+            def __init__(self, *,
                          callbacks: Optional[CallbackSet],
                          address: int,
                          logger_handle: str,
                          inst_name: str,
                          dut_stride : int,
                          dut_dimensions : Tuple[int, ...]):
-
 
                 super().__init__(callbacks=callbacks, address=address, logger_handle=logger_handle,
                                  inst_name=inst_name, parent=None )
@@ -187,6 +185,7 @@ class Test1DArray(ArrayBase):
                 with self.assertRaises(IndexError):
                     _ = subset_slice[index]
 
+
 class Test2DArray(ArrayBase):
     """
     Test for 2D arrays
@@ -256,6 +255,7 @@ class Test2DArray(ArrayBase):
         chunk = self.dut[2:-2, 3:-3]
         for index, entry in zip(product(range(2,8), range(3,9)), chunk):
             self.assertEqual(entry.address, self.calculate_address(index))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_optimised_reg_array.py
+++ b/tests/unit_tests/test_optimised_reg_array.py
@@ -62,7 +62,6 @@ class ArrayBase(CallBackTestWrapper, ABC):
         address based on array index
         """
 
-
     def setUp(self) -> None:
 
         class DUTWrapper(AddressMap):
@@ -71,7 +70,7 @@ class ArrayBase(CallBackTestWrapper, ABC):
             """
 
             # pylint: disable=too-many-arguments,duplicate-code
-            def __init__(self,
+            def __init__(self, *,
                          callbacks: Optional[CallbackSet],
                          address: int,
                          logger_handle: str,
@@ -80,18 +79,17 @@ class ArrayBase(CallBackTestWrapper, ABC):
                          dut_dimensions : Tuple[int, ...],
                          RegisterArrayType):
 
-
                 super().__init__(callbacks=callbacks, address=address, logger_handle=logger_handle,
                                  inst_name=inst_name, parent=None )
 
                 self.__dut = RegisterArrayType(logger_handle='dut',
-                                                 inst_name='dut',
-                                                 parent=self,
-                                                 address=address,
-                                                 accesswidth=32,
-                                                 width=32,
-                                                 stride=dut_stride,
-                                                 dimensions=dut_dimensions)
+                                               inst_name='dut',
+                                               parent=self,
+                                               address=address,
+                                               accesswidth=32,
+                                               width=32,
+                                               stride=dut_stride,
+                                               dimensions=dut_dimensions)
 
             def get_memories(self, unroll: bool = False) -> \
                     Iterator[Union[Memory, Tuple[Memory, ...]]]:
@@ -221,13 +219,12 @@ class Test1DArrayReadWrite(ArrayBase):
                 with self.dut.single_read_modify_write(verify=True) as dut_context:
                     dut_context[2].write(4)
 
-
-
     def test_blockless_context_manager(self):
         """
         test the context manager that will perform a set of read operation,
         modify write operations with optional read-verify
         """
+
 
 class Test1DArrayReadOnly(ArrayBase):
     """
@@ -288,6 +285,7 @@ class Test1DArrayReadOnly(ArrayBase):
         test the context manager that will perform a set of read operation,
         modify write operations with optional read-verify
         """
+
 
 class Test1DArrayWriteOnly(ArrayBase):
     """
@@ -352,7 +350,6 @@ class Test1DArrayWriteOnly(ArrayBase):
         test the context manager that will perform a set of read operation,
         modify write operations with optional read-verify
         """
-
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_reg.py
+++ b/tests/unit_tests/test_reg.py
@@ -45,7 +45,7 @@ class RegTestBase(CallBackTestWrapper, ABC):
             """
 
             # pylint: disable=duplicate-code
-            def __init__(self,
+            def __init__(self, *,
                          callbacks: Optional[CallbackSet],
                          address: int,
                          logger_handle: str,
@@ -103,6 +103,7 @@ class RegTestBase(CallBackTestWrapper, ABC):
                                       logger_handle='dut_wrapper', inst_name='dut_wrapper',
                                       reg_type=self.reg_type)
 
+
 class TestReadOnly(RegTestBase):
     """
     Test for read only register
@@ -128,7 +129,6 @@ class TestReadOnly(RegTestBase):
         Register under test
         """
         return cast(ReadOnlyRegisterToTest, self.dut_wrapper.dut)
-
 
     def test_register_read(self) -> None:
         """
@@ -182,6 +182,7 @@ class TestReadOnly(RegTestBase):
 
             write_patch.assert_not_called()
 
+
 class TestWrite(RegTestBase):
     """
     Test for write only register
@@ -231,6 +232,7 @@ class TestWrite(RegTestBase):
                                                width=self.dut.width,
                                                accesswidth=self.dut.accesswidth, data=1)
             read_patch.assert_not_called()
+
 
 class TestReadWrite(RegTestBase):
     """
@@ -424,7 +426,6 @@ class TestReadWrite(RegTestBase):
                                                width=self.dut.width,
                                                accesswidth=self.dut.accesswidth)
             write_patch.assert_not_called()
-
 
     def test_context_manager_read(self) -> None:
         """


### PR DESCRIPTION
pylint 3.3.1 introduces a new check for the maximum number of positional arguments by default.