### PR TITLE
Incorrect top level name when parameter is set at command line

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -175,6 +175,7 @@ jobs:
           peakrdl python tests/testcases/extended_memories.rdl -o peakrdl_out/raw/
           peakrdl python tests/testcases/user_defined_properties.rdl -o peakrdl_out/raw/ --udp bool_property_to_include
           peakrdl python tests/testcases/reserved_elements.rdl -o peakrdl_out/raw/ --hide_regex "(?:[\w_\[\]]+\.)+RSVD"
+          peakrdl python tests/testcases/parametrised_top.rdl -o peakrdl_out/raw/ -P MY_PARAM=3
           python -m unittest discover -s peakrdl_out/raw
 
           peakrdl python tests/testcases/basic.rdl -o peakrdl_out/raw_async/ --async

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -17,4 +17,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Variables that describes the peakrdl-python Package
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -17,4 +17,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Variables that describes the peakrdl-python Package
 """
-__version__ = "1.0.2"
+__version__ = "1.1.0"

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -735,8 +735,18 @@ class PythonExporter:
                 # de-duplicate the values
                 raise RuntimeError("node is already in the lookup dictionary")
 
-            cand_type_name = get_fully_qualified_type_name(child_node)
+            if child_node == node:
+                # in the case of the top node the type name should match the instance name
+                cand_type_name = child_node.inst_name
+            else:
+                cand_type_name = get_fully_qualified_type_name(child_node)
             if cand_type_name in self.node_type_name.values():
+                if child_node == node:
+                    raise RuntimeError(
+                        f'Top Node name {cand_type_name} already used by instance ' \
+                        + str(list(self.node_type_name.keys())
+                          [list(self.node_type_name.values()).index(cand_type_name)])
+                    )
                 self.node_type_name[child_inst] = cand_type_name + '_0x' + hex(hash(child_inst))
             else:
                 self.node_type_name[child_inst] = cand_type_name

--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -492,5 +492,5 @@ if __name__ == '__main__':
         print('write data:0x%X to address:0x%X'%(data, addr))
 
     # create an instance of the class
-    {{top_node.inst_name}} = {{top_node.inst_name)}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
+    {{top_node.inst_name}} = {{top_node.inst_name}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
                                                                                                      write_callback=write_addr_space))

--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -248,7 +248,7 @@ class {{get_fully_qualified_type_name(node)}}_array_cls({% if asyncoutput %}Asyn
 {%- endmacro %}
 
 {%- macro addrmap_class(node) %}
-class {{get_fully_qualified_type_name(node)}}_cls({% if asyncoutput %}Async{% endif %}AddressMap):
+class {% if node == top_node %}{{node.inst_name}}{% else %}{{get_fully_qualified_type_name(node)}}{% endif %}_cls({% if asyncoutput %}Async{% endif %}AddressMap):
     """
     Class to represent a address map in the register model
 

--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -248,7 +248,7 @@ class {{get_fully_qualified_type_name(node)}}_array_cls({% if asyncoutput %}Asyn
 {%- endmacro %}
 
 {%- macro addrmap_class(node) %}
-class {% if node == top_node %}{{node.inst_name}}{% else %}{{get_fully_qualified_type_name(node)}}{% endif %}_cls({% if asyncoutput %}Async{% endif %}AddressMap):
+class {{get_fully_qualified_type_name(node)}}_cls({% if asyncoutput %}Async{% endif %}AddressMap):
     """
     Class to represent a address map in the register model
 
@@ -492,5 +492,5 @@ if __name__ == '__main__':
         print('write data:0x%X to address:0x%X'%(data, addr))
 
     # create an instance of the class
-    {{top_node.inst_name}} = {{top_node.inst_name}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
+    {{top_node.inst_name}} = {{get_fully_qualified_type_name(top_node)}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
                                                                                                      write_callback=write_addr_space))

--- a/src/peakrdl_python/templates/addrmap.py.jinja
+++ b/src/peakrdl_python/templates/addrmap.py.jinja
@@ -492,5 +492,5 @@ if __name__ == '__main__':
         print('write data:0x%X to address:0x%X'%(data, addr))
 
     # create an instance of the class
-    {{top_node.inst_name}} = {{get_fully_qualified_type_name(top_node)}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
+    {{top_node.inst_name}} = {{top_node.inst_name)}}_cls(callbacks = {% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_addr_space,
                                                                                                      write_callback=write_addr_space))

--- a/src/peakrdl_python/templates/addrmap_simulation_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_simulation_tb.py.jinja
@@ -35,10 +35,10 @@ from enum import IntEnum
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}sim_lib.register import Register,MemoryRegister
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}sim_lib.field import Field
 
-from ._{{top_node.inst_name}}_sim_test_base import {{top_node.type_name}}_SimTestCase, {{top_node.type_name}}_SimTestCase_BlockAccess
+from ._{{top_node.inst_name}}_sim_test_base import {{top_node.inst_name}}_SimTestCase, {{top_node.inst_name}}_SimTestCase_BlockAccess
 from ._{{top_node.inst_name}}_sim_test_base import __name__ as base_name
 
-class {{fq_block_name}}_single_access({{top_node.type_name}}_SimTestCase): # type: ignore[valid-type,misc]
+class {{fq_block_name}}_single_access({{top_node.inst_name}}_SimTestCase): # type: ignore[valid-type,misc]
 
     {% if asyncoutput %}async {% endif %}def test_register_read_and_write(self) -> None:
         """
@@ -335,7 +335,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_SimTestCase): # typ
 
 
 
-class {{fq_block_name}}_block_access({{top_node.type_name}}_SimTestCase_BlockAccess): # type: ignore[valid-type,misc]
+class {{fq_block_name}}_block_access({{top_node.inst_name}}_SimTestCase_BlockAccess): # type: ignore[valid-type,misc]
     """
     tests for all the block access methods
     """

--- a/src/peakrdl_python/templates/addrmap_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_tb.py.jinja
@@ -35,9 +35,9 @@ from enum import IntEnum
 
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import RegisterWriteVerifyError, UnsupportedWidthError
 
-from ..reg_model.{{top_node.type_name}} import {{top_node.type_name}}_cls
+from ..reg_model.{{top_node.inst_name}} import {{top_node.inst_name}}_cls
 {% for property_enum in dependent_property_enum %}
-from ..reg_model.{{top_node.type_name}} import {{property_enum.type_name}}_property_enumcls
+from ..reg_model.{{top_node.inst_name}} import {{property_enum.type_name}}_property_enumcls
 {% endfor %}
 
 
@@ -67,12 +67,12 @@ from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import 
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import Field
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import Reg
 
-from ._{{top_node.inst_name}}_test_base import {{top_node.type_name}}_TestCase, {{top_node.type_name}}_TestCase_BlockAccess, {{top_node.type_name}}_TestCase_AltBlockAccess
+from ._{{top_node.inst_name}}_test_base import {{top_node.inst_name}}_TestCase, {{top_node.inst_name}}_TestCase_BlockAccess, {{top_node.inst_name}}_TestCase_AltBlockAccess
 from ._{{top_node.inst_name}}_test_base import __name__ as base_name
 
 {% from 'addrmap_udp_property.py.jinja' import udp_property_dict_entry with context %}
 
-class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: ignore[valid-type,misc]
+class {{fq_block_name}}_single_access({{top_node.inst_name}}_TestCase): # type: ignore[valid-type,misc]
 
     def test_inst_name(self)  -> None:
         """
@@ -1329,7 +1329,7 @@ class {{fq_block_name}}_single_access({{top_node.type_name}}_TestCase): # type: 
 
 
 
-class {{fq_block_name}}_block_access({{top_node.type_name}}_TestCase_BlockAccess): # type: ignore[valid-type,misc]
+class {{fq_block_name}}_block_access({{top_node.inst_name}}_TestCase_BlockAccess): # type: ignore[valid-type,misc]
     """
     tests for all the block access methods
     """
@@ -1488,7 +1488,7 @@ class {{fq_block_name}}_block_access({{top_node.type_name}}_TestCase_BlockAccess
 
         {%- endfor %}
 
-class {{fq_block_name}}_alt_block_access({{top_node.type_name}}_TestCase_AltBlockAccess): # type: ignore[valid-type,misc]
+class {{fq_block_name}}_alt_block_access({{top_node.inst_name}}_TestCase_AltBlockAccess): # type: ignore[valid-type,misc]
     """
     tests for all the block access methods with the alternative callbacks, this is a simpler
     version of the tests above

--- a/src/peakrdl_python/templates/baseclass_simulation_tb.py.jinja
+++ b/src/peakrdl_python/templates/baseclass_simulation_tb.py.jinja
@@ -37,23 +37,23 @@ from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import 
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import NormalCallbackSet{% if legacy_block_access %}Legacy{% endif %}
 {% endif %}
 
-from ._{{top_node.inst_name}}_test_base import {{top_node.type_name}}_TestCase, {{top_node.type_name}}_TestCase_BlockAccess
+from ._{{top_node.inst_name}}_test_base import {{top_node.inst_name}}_TestCase, {{top_node.inst_name}}_TestCase_BlockAccess
 
-from ..reg_model.{{top_node.type_name}} import {{top_node.type_name}}_cls
-from ..sim.{{top_node.type_name}} import {{top_node.type_name}}_simulator_cls
+from ..reg_model.{{top_node.inst_name}} import {{top_node.inst_name}}_cls
+from ..sim.{{top_node.inst_name}} import {{top_node.inst_name}}_simulator_cls
 
-class {{top_node.type_name}}_SimTestCase({{top_node.type_name}}_TestCase): # type: ignore[valid-type,misc]
+class {{top_node.inst_name}}_SimTestCase({{top_node.inst_name}}_TestCase): # type: ignore[valid-type,misc]
 
     def setUp(self) -> None:
-        self.sim = {{top_node.type_name}}_simulator_cls(address=0)
-        self.dut = {{top_node.type_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=self.sim.read,
+        self.sim = {{top_node.inst_name}}_simulator_cls(address=0)
+        self.dut = {{top_node.inst_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=self.sim.read,
                                                           write_callback=self.sim.write))
 
-class {{top_node.type_name}}_SimTestCase_BlockAccess({{top_node.type_name}}_TestCase_BlockAccess): # type: ignore[valid-type,misc]
+class {{top_node.inst_name}}_SimTestCase_BlockAccess({{top_node.inst_name}}_TestCase_BlockAccess): # type: ignore[valid-type,misc]
 
     def setUp(self) -> None:
-        self.sim = {{top_node.type_name}}_simulator_cls(address=0)
-        self.dut = {{top_node.type_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=self.sim.read,
+        self.sim = {{top_node.inst_name}}_simulator_cls(address=0)
+        self.dut = {{top_node.inst_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=self.sim.read,
                                                           write_callback=self.sim.write,
                                                           read_block_callback=self.sim.read_block,
                                                           write_block_callback=self.sim.write_block))

--- a/src/peakrdl_python/templates/baseclass_tb.py.jinja
+++ b/src/peakrdl_python/templates/baseclass_tb.py.jinja
@@ -38,7 +38,7 @@ from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}lib import 
 {% endif %}
 
 
-from ..reg_model.{{top_node.type_name}} import {{top_node.type_name}}_cls
+from ..reg_model.{{top_node.inst_name}} import {{top_node.inst_name}}_cls
 {% if asyncoutput %}
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}sim_lib.dummy_callbacks import async_dummy_read as read_addr_space
 from {% if skip_lib_copy %}src.peakrdl_python.{% else %}..{% endif %}sim_lib.dummy_callbacks import async_dummy_write as write_addr_space
@@ -83,10 +83,10 @@ else:
 TestCaseBase = unittest.TestCase
 {% endif %}
 
-class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,misc]
+class {{top_node.inst_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,misc]
 
     def setUp(self) -> None:
-        self.dut = {{top_node.type_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_callback,
+        self.dut = {{top_node.inst_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_callback,
                                                           write_callback=write_callback))
 
     @staticmethod
@@ -106,22 +106,22 @@ class {{top_node.type_name}}_TestCase(TestCaseBase): # type: ignore[valid-type,m
                 result |= 1 << (number_bits - 1 - i)
         return result
 
-class {{top_node.type_name}}_TestCase_BlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
+class {{top_node.inst_name}}_TestCase_BlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
 
     def setUp(self) -> None:
-        self.dut = {{top_node.type_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_callback,
+        self.dut = {{top_node.inst_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if legacy_block_access %}Legacy{% endif %}(read_callback=read_callback,
                                                           write_callback=write_callback,
                                                           read_block_callback=read_block_callback,
                                                           write_block_callback=write_block_callback))
 
-class {{top_node.type_name}}_TestCase_AltBlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
+class {{top_node.inst_name}}_TestCase_AltBlockAccess(TestCaseBase): # type: ignore[valid-type,misc]
     """
     Based test to use with the alternative call backs, this allow the legacy output API to be tested
     with the new callbacks and visa versa.
     """
 
     def setUp(self) -> None:
-        self.dut = {{top_node.type_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if not legacy_block_access %}Legacy{% endif %}(
+        self.dut = {{top_node.inst_name}}_cls(callbacks={% if asyncoutput %}AsyncCallbackSet{% else %}NormalCallbackSet{% endif %}{% if not legacy_block_access %}Legacy{% endif %}(
                                                           read_callback=read_callback,
                                                           write_callback=write_callback,
                                                           read_block_callback=read_block_callback_alt,

--- a/tests/testcases/parametrised_top.rdl
+++ b/tests/testcases/parametrised_top.rdl
@@ -1,0 +1,13 @@
+addrmap parametrised_top #(bit MY_PARAM = 12) {
+
+    default regwidth = 32;
+    default accesswidth = 32;
+
+    reg {
+        default sw = rw;
+        default hw = rw;
+        name = "ReadWriteRegister";
+        field {} my_field[32] = 0;
+    } my_reg[MY_PARAM];
+
+};


### PR DESCRIPTION
With the case below:

```
addrmap my_map #(bit MY_PARAM = 12) {

      name  = "mymap";

      default regwidth = 32;

      default accesswidth = 32;

      default sw = rw;

      default hw = rw;

 

      reg

      {

            field {} my_field[32] = 0;

      } my_reg[MY_PARAM];

};
```

When the parameter is set at the command line, such as with `peakrdl python -P MY_PARAM=3` the tool creates a python class with the parameter name & value included. That is, the top-levelclass is named `my_map_MY_PARAM_3_cls` as generated by the `get_fully_qualified_type_name` function. I'd think that the top-level node name should be the same as the instance name for the top-level class.

I think the solution would be to use the instance name on the top-level address map class.

 