### PR TITLE
Make `legacy_enum_type ` and `legacy_block_access ` off by default.

### DIFF
--- a/docs/generated_package.rst
+++ b/docs/generated_package.rst
@@ -174,6 +174,10 @@ Legacy Block Callback and Block Access
       * ``NormalCallbackSetLegacy`` for standard python function callbacks
       * ``AsyncCallbackSetLegacy`` for async python function callbacks, these are called from the library using ``await``
 
+.. versionchanged:: 3.0.0
+
+    The ``legacy_block_access`` will now default to ``False``
+
 Legacy Enumeration Types
 ------------------------
 
@@ -186,6 +190,10 @@ Legacy Enumeration Types
 
    There was a small risk this may impact some users code, in the case of advanced usage of the
    enumeration. The old behaviour can be brought back using the ``legacy_enum_type`` build option.
+
+.. versionchanged:: 3.0.0
+
+    The ``legacy_enum_type`` will now default to ``False``
 
 
 Using the Register Access Layer

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -80,7 +80,8 @@ class Exporter(ExporterSubcommandPlugin):
         arg_group.add_argument('--legacy_block_access', action='store_true',
                                dest='legacy_block_access',
                                help='peakrdl python has two methods to hold blocks of data, the '
-                                    'legacy mode based on array.array or the new mode using lists')
+                                    'legacy mode based on array.array or the new mode using '
+                                    'lists. This option will be removed in version 4.0')
         arg_group.add_argument('--show_hidden', action='store_true',
                                dest='show_hidden',
                                help='show addrmap, regfile, memory, register and fields that '
@@ -100,7 +101,8 @@ class Exporter(ExporterSubcommandPlugin):
                                dest='legacy_enum_type',
                                help='peakrdl python has two ways to define field encoding as '
                                      'enums new method and an old method based on IntEnum. '
-                                     'Setting this to true will restore the old behaviour')
+                                     'Setting this to true will restore the old behaviour.'
+                                     ' This option will be removed in version 4.0')
         arg_group.add_argument('--skip_systemrdl_name_and_desc_properties', action='store_true',
                                dest='skip_systemrdl_name_and_desc_properties',
                                help='peakrdl python includes the system RDL name and desc '

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -951,12 +951,12 @@ class PythonExporter:
                skip_test_case_generation: bool = False,
                delete_existing_package_content: bool = True,
                skip_library_copy: bool = False,
-               legacy_block_access: bool = True,
+               legacy_block_access: bool = False,
                show_hidden: bool = False,
                user_defined_properties_to_include: Optional[list[str]] = None,
                user_defined_properties_to_include_regex: Optional[str] = None,
                hidden_inst_name_regex: Optional[str] = None,
-               legacy_enum_type: bool = True,
+               legacy_enum_type: bool = False,
                skip_systemrdl_name_and_desc_properties: bool = False,
                skip_systemrdl_name_and_desc_in_docstring: bool = False,
                register_class_per_generated_file: int =
@@ -1011,6 +1011,7 @@ class PythonExporter:
             legacy_enum_type: version 1.2 introduced a new Enum type that allows system
                               rdl ``name`` and ``desc`` properties on field encoding
                               to be included. The legacy mode uses python IntEnum.
+                              .. version-deprecated:: 3.0
             skip_systemrdl_name_and_desc_properties (bool) : version 1.2 introduced new properties
                                                              that include the systemRDL name and
                                                              desc as properties of the built
@@ -1053,6 +1054,16 @@ class PythonExporter:
         Returns:
             modules that have been exported:
         """
+        if legacy_enum_type:
+            warnings.warn('legacy_enum_type is deprecated and '
+                          'will be removed from a future version please try the new mode',
+                          category=DeprecationWarning)
+
+        if legacy_block_access:
+            warnings.warn('legacy_block_access is deprecated and '
+                          'will be removed from a future version please try the new mode',
+                          category=DeprecationWarning)
+
 
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):


### PR DESCRIPTION
closes #278
closes #181