### PR TITLE
Remove the Legacy Enum

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -142,8 +142,6 @@ jobs:
           sleep 10
           python -m generate_and_test --RDL_source_file tests/testcases/accelera-generic_example.rdl --root_node some_register_map --legacy_block_access
           sleep 10
-          python -m generate_and_test --RDL_source_file tests/testcases/accelera-generic_example.rdl --root_node some_register_map --legacy_enum_type
-          sleep 10
           python -m generate_and_test --RDL_source_file tests/testcases/accelera-generic_example.rdl --root_node some_register_map --copy_libraries
           sleep 10
           python -m generate_and_test --RDL_source_file tests/testcases/accelera-generic_example.rdl --root_node some_register_map --hashing_mode PYTHONHASH
@@ -221,9 +219,6 @@ jobs:
           
           peakrdl python tests/testcases/basic.rdl -o peakrdl_out/no_lib/ --skip_library_copy
           python -m unittest discover -s peakrdl_out/no_lib
-          
-          peakrdl python tests/testcases/enum_example.rdl -o peakrdl_out/raw_legacy_enum/ --legacy_enum_type
-          python -m unittest discover -s peakrdl_out/raw_legacy_enum
 
           # test a TOMl file that passes in overridden templates
           peakrdl python tests/testcases/basic.rdl -o peakrdl_out/simple_user_template/ --peakrdl-cfg tests/alternative_templates_toml/peakrdl.toml

--- a/README.md
+++ b/README.md
@@ -130,4 +130,13 @@ the following options were changed:
   This had some restrictions, so the a new methodology based on the `list` type was introduced in version 0.9.
   The old array based behaviour is no longer the default but can be turned on using the `legacy_block_access`
 
+## 4.0.0
+
+some legacy features from the early versions were removed in release 4.0.0, the following options were changed:
+- Version 1.2 introduced a new custom enumeration type (rather than using `IntEnum`) in order to allow
+  the content to `name` and `desc` systemRDL properties in be accessible. Version 4.0.0 removed the option to use `IntEnum`
+- The first versions of PeakRDL Python used the built-in `Array` type for accessing blocks of data efficiently.
+  This had some restrictions, so a new methodology based on the `list` type was introduced in version 0.9.
+  The old array based behaviour was removed in this version
+
 

--- a/docs/generated_package.rst
+++ b/docs/generated_package.rst
@@ -187,24 +187,6 @@ Legacy Block Callback and Block Access
 
     The ``legacy_block_access`` will now default to ``False``
 
-Legacy Enumeration Types
-------------------------
-
-.. versionchanged:: 1.2.0
-
-   Previous versions of PeakRDL Python used `IntEnum` for the the field encoding. This had a
-   limitation that the metadata from the system RDL code, notably the ``name`` and ``desc``
-   property could not be included. A new data type for the enumerations was introduced in
-   version 1.2.0.
-
-   There was a small risk this may impact some users code, in the case of advanced usage of the
-   enumeration. The old behaviour can be brought back using the ``legacy_enum_type`` build option.
-
-.. versionchanged:: 3.0.0
-
-    The ``legacy_enum_type`` will now default to ``False``
-
-
 Using the Register Access Layer
 ===============================
 

--- a/generate_and_test.py
+++ b/generate_and_test.py
@@ -97,11 +97,6 @@ CommandLineParser.add_argument('--full_inst_file', dest='full_inst_file',
                                type=pathlib.Path, required=False,
                                help='export a text file with a list of the all qualified instance'
                                     'names in the systemRDL')
-CommandLineParser.add_argument('--legacy_enum_type', action='store_true',
-                               dest='legacy_enum_type',
-                               help='peakrdl python has ways to define field encoding as enums a '
-                                    'a new method and an old method based on IntEnum. Setting '
-                                    'this to true will restore the old behaviour')
 CommandLineParser.add_argument('--skip_systemrdl_name_and_desc_properties',
                                action='store_true',
                                dest='skip_systemrdl_name_and_desc_properties',
@@ -224,7 +219,6 @@ if __name__ == '__main__':
         user_defined_properties_to_include=CommandLineArgs.udp,
         user_defined_properties_to_include_regex=CommandLineArgs.udp_regex,
         hidden_inst_name_regex=CommandLineArgs.hide_regex,
-        legacy_enum_type=CommandLineArgs.legacy_enum_type,
         skip_systemrdl_name_and_desc_properties=
         CommandLineArgs.skip_systemrdl_name_and_desc_properties,
         skip_systemrdl_name_and_desc_in_docstring=

--- a/generate_testcases.py
+++ b/generate_testcases.py
@@ -84,7 +84,6 @@ def compile_rdl(infile: str,
 def generate(root: Node, outdir: str,
              asyncoutput: bool = False,
              legacy_block_access: bool = True,
-             legacy_enum_type: bool = True,
              copy_library: bool = False,
              skip_systemrdl_name_and_desc_in_docstring: bool = False,
              hashing_mode: NodeHashingMethod = NodeHashingMethod.PYTHONHASH) -> List[str]:
@@ -96,8 +95,6 @@ def generate(root: Node, outdir: str,
         outdir: directory to store the result in
         legacy_block_access: If set to True the code build a register model the legacy array block
                              access as opposed to the newer list based
-        legacy_enum_type: If set to True the code with build with the old style IntEnum rather than
-                          the new style SystemRDLEnum
 
     Returns:
         List of strings with the module names generated
@@ -108,7 +105,6 @@ def generate(root: Node, outdir: str,
         root, outdir,  # type: ignore[no-untyped-call]
         asyncoutput=asyncoutput,
         legacy_block_access=legacy_block_access,
-        legacy_enum_type=legacy_enum_type,
         skip_library_copy=not copy_library,
         skip_systemrdl_name_and_desc_in_docstring=
         skip_systemrdl_name_and_desc_in_docstring,
@@ -174,7 +170,6 @@ if __name__ == '__main__':
             _ = generate(root, str(output_path / folder_parts),
                          asyncoutput=asyncoutput,
                          legacy_block_access=legacy,
-                         legacy_enum_type=legacy,
                          copy_library=CommandLineArgs.copy_libraries,
                          skip_systemrdl_name_and_desc_in_docstring=skip_name_and_desc_in_docstring,
                          hashing_mode=hashing_method)

--- a/src/peakrdl_python/__about__.py
+++ b/src/peakrdl_python/__about__.py
@@ -17,4 +17,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Variables that describes the peakrdl-python Package
 """
-__version__ = "3.1.0"
+__version__ = "4.0.0rc1"

--- a/src/peakrdl_python/__peakrdl__.py
+++ b/src/peakrdl_python/__peakrdl__.py
@@ -97,12 +97,6 @@ class Exporter(ExporterSubcommandPlugin):
                                     'be hidden')
         arg_group.add_argument('--skip_library_copy', action='store_true',
                                help='skip the copy of the library code into the generated package')
-        arg_group.add_argument('--legacy_enum_type', action='store_true',
-                               dest='legacy_enum_type',
-                               help='peakrdl python has two ways to define field encoding as '
-                                     'enums new method and an old method based on IntEnum. '
-                                     'Setting this to true will restore the old behaviour.'
-                                     ' This option will be removed in version 4.0')
         arg_group.add_argument('--skip_systemrdl_name_and_desc_properties', action='store_true',
                                dest='skip_systemrdl_name_and_desc_properties',
                                help='peakrdl python includes the system RDL name and desc '
@@ -190,7 +184,6 @@ class Exporter(ExporterSubcommandPlugin):
             user_defined_properties_to_include_regex=options.udp_regex,
             hidden_inst_name_regex=options.hide_regex,
             skip_library_copy=options.skip_library_copy,
-            legacy_enum_type=options.legacy_enum_type,
             skip_systemrdl_name_and_desc_properties=
                 options.skip_systemrdl_name_and_desc_properties,
             skip_systemrdl_name_and_desc_in_docstring=

--- a/src/peakrdl_python/exporter.py
+++ b/src/peakrdl_python/exporter.py
@@ -194,7 +194,6 @@ class PythonExporter:
                            legacy_block_access: bool,
                            udp_include_func: ShowUDPCallback,
                            hide_node_func: HideNodeCallback,
-                           legacy_enum_type: bool,
                            skip_systemrdl_name_and_desc_properties: bool,
                            skip_systemrdl_name_and_desc_in_docstring: bool,
                            register_class_per_generated_file: int,
@@ -264,7 +263,6 @@ class PythonExporter:
                 self._get_dependent_property_enum(unique_component_walker),
             'hide_node_func': hide_node_func,
             'visible_nonsignal_node' : visible_nonsignal_node,
-            'legacy_enum_type': legacy_enum_type,
             'skip_systemrdl_name_and_desc_properties': skip_systemrdl_name_and_desc_properties,
         }
         if legacy_block_access is True:
@@ -291,7 +289,6 @@ class PythonExporter:
                 asyncoutput=asyncoutput,
                 legacy_block_access=legacy_block_access,
                 hide_node_func=hide_node_func,
-                legacy_enum_type=legacy_enum_type,
                 skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties,
                 skip_systemrdl_name_and_desc_in_docstring=
                    skip_systemrdl_name_and_desc_in_docstring,
@@ -307,7 +304,6 @@ class PythonExporter:
             asyncoutput=asyncoutput,
             legacy_block_access=legacy_block_access,
             hide_node_func=hide_node_func,
-            legacy_enum_type=legacy_enum_type,
             skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties,
             skip_systemrdl_name_and_desc_in_docstring=skip_systemrdl_name_and_desc_in_docstring,
             unique_component_walker=unique_component_walker,
@@ -320,7 +316,6 @@ class PythonExporter:
             package=package,
             skip_lib_copy=skip_lib_copy,
             asyncoutput=asyncoutput,
-            legacy_enum_type=legacy_enum_type,
             skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties,
             skip_systemrdl_name_and_desc_in_docstring=skip_systemrdl_name_and_desc_in_docstring,
             unique_component_walker=unique_component_walker,
@@ -332,7 +327,6 @@ class PythonExporter:
                 top_block=top_block,
                 package=package,
                 skip_lib_copy=skip_lib_copy,
-                legacy_enum_type=legacy_enum_type,
                 skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties,
                 unique_component_walker=unique_component_walker,
                 enum_field_class_per_generated_file=enum_field_class_per_generated_file)
@@ -342,8 +336,7 @@ class PythonExporter:
             'top_node': top_block,
             'unique_property_enums':
                 self._get_dependent_property_enum(unique_component_walker),
-            'skip_lib_copy': skip_lib_copy,
-            'legacy_enum_type': legacy_enum_type,
+            'skip_lib_copy': skip_lib_copy
         }
 
         self.__stream_jinja_template(template_name="property_enums.py.jinja",
@@ -359,7 +352,6 @@ class PythonExporter:
                                      asyncoutput: bool,
                                      legacy_block_access: bool,
                                      hide_node_func: HideNodeCallback,
-                                     legacy_enum_type: bool,
                                      skip_systemrdl_name_and_desc_properties: bool,
                                      skip_systemrdl_name_and_desc_in_docstring: bool,
                                      unique_component_walker: UniqueComponents,
@@ -440,7 +432,6 @@ class PythonExporter:
                     'get_field_default_value': get_field_default_value,
                     'skip_lib_copy': skip_lib_copy,
                     'uses_enum': uses_enum(top_block),
-                    'legacy_enum_type': legacy_enum_type,
                     'legacy_block_access': legacy_block_access,
                     'skip_systemrdl_name_and_desc_properties':
                         skip_systemrdl_name_and_desc_properties,
@@ -469,7 +460,6 @@ class PythonExporter:
                                     asyncoutput: bool,
                                     legacy_block_access: bool,
                                     hide_node_func: HideNodeCallback,
-                                    legacy_enum_type: bool,
                                     skip_systemrdl_name_and_desc_properties: bool,
                                     skip_systemrdl_name_and_desc_in_docstring: bool,
                                     unique_component_walker: UniqueComponents,
@@ -541,7 +531,6 @@ class PythonExporter:
                     'get_field_default_value': get_field_default_value,
                     'skip_lib_copy': skip_lib_copy,
                     'uses_enum': uses_enum(top_block),
-                    'legacy_enum_type': legacy_enum_type,
                     'legacy_block_access': legacy_block_access,
                     'skip_systemrdl_name_and_desc_properties':
                         skip_systemrdl_name_and_desc_properties,
@@ -567,7 +556,6 @@ class PythonExporter:
                                   package: GeneratedPackage,
                                   skip_lib_copy: bool,
                                   asyncoutput: bool,
-                                  legacy_enum_type: bool,
                                   skip_systemrdl_name_and_desc_properties: bool,
                                   skip_systemrdl_name_and_desc_in_docstring: bool,
                                   unique_component_walker: UniqueComponents,
@@ -612,7 +600,6 @@ class PythonExporter:
                                                skip_systemrdl_name_and_desc_in_docstring),
                     'skip_lib_copy': skip_lib_copy,
                     'uses_enum': uses_enum(top_block),
-                    'legacy_enum_type': legacy_enum_type,
                     'skip_systemrdl_name_and_desc_properties':
                         skip_systemrdl_name_and_desc_properties,
                     'raise_template_error': self._raise_template_error,
@@ -632,7 +619,6 @@ class PythonExporter:
                                        top_block: AddrmapNode,
                                        package: GeneratedPackage,
                                        skip_lib_copy: bool,
-                                       legacy_enum_type: bool,
                                        skip_systemrdl_name_and_desc_properties: bool,
                                        unique_component_walker: UniqueComponents,
                                        enum_field_class_per_generated_file: int) -> None:
@@ -658,7 +644,6 @@ class PythonExporter:
                     'top_node': top_block,
                     'unique_enums': unique_enums_subset,
                     'skip_lib_copy': skip_lib_copy,
-                    'legacy_enum_type': legacy_enum_type,
                     'skip_systemrdl_name_and_desc_properties':
                         skip_systemrdl_name_and_desc_properties
                 }
@@ -757,15 +742,13 @@ class PythonExporter:
                             package: GeneratedPackage,
                             skip_lib_copy: bool,
                             asyncoutput: bool,
-                            legacy_block_access: bool,
-                            legacy_enum_type: bool) -> None:
+                            legacy_block_access: bool) -> None:
 
         context = {
             'top_node': top_block,
             'asyncoutput': asyncoutput,
             'skip_lib_copy': skip_lib_copy,
-            'legacy_block_access': legacy_block_access,
-            'legacy_enum_type': legacy_enum_type
+            'legacy_block_access': legacy_block_access
         }
 
         self.__stream_jinja_template(template_name="baseclass_tb.py.jinja",
@@ -787,7 +770,6 @@ class PythonExporter:
                        legacy_block_access: bool,
                        udp_include_func: ShowUDPCallback,
                        hide_node_func: HideNodeCallback,
-                       legacy_enum_type: bool,
                        skip_systemrdl_name_and_desc_properties: bool,
                        ) -> None:
 
@@ -882,7 +864,6 @@ class PythonExporter:
                 'udp_include_func': udp_include_func,
                 'get_properties_to_include': get_properties_to_include,
                 'hide_node_func': hide_node_func,
-                'legacy_enum_type': legacy_enum_type,
                 'skip_systemrdl_name_and_desc_properties': skip_systemrdl_name_and_desc_properties,
                 'node_iterator_entry': node_iterator_entry,
             }
@@ -973,7 +954,6 @@ class PythonExporter:
                user_defined_properties_to_include: Optional[list[str]] = None,
                user_defined_properties_to_include_regex: Optional[str] = None,
                hidden_inst_name_regex: Optional[str] = None,
-               legacy_enum_type: bool = False,
                skip_systemrdl_name_and_desc_properties: bool = False,
                skip_systemrdl_name_and_desc_in_docstring: bool = False,
                register_class_per_generated_file: int =
@@ -1025,10 +1005,6 @@ class PythonExporter:
             hidden_inst_name_regex: A regular expression which will hide any fully
                                     qualified instance name that matches, set to None to
                                     for this to have no effect
-            legacy_enum_type: version 1.2 introduced a new Enum type that allows system
-                              rdl ``name`` and ``desc`` properties on field encoding
-                              to be included. The legacy mode uses python IntEnum.
-                              .. version-deprecated:: 3.0
             skip_systemrdl_name_and_desc_properties (bool) : version 1.2 introduced new properties
                                                              that include the systemRDL name and
                                                              desc as properties of the built
@@ -1071,11 +1047,6 @@ class PythonExporter:
         Returns:
             modules that have been exported:
         """
-        if legacy_enum_type:
-            warnings.warn('legacy_enum_type is deprecated and '
-                          'will be removed from a future version please try the new mode',
-                          category=DeprecationWarning)
-
         if legacy_block_access:
             warnings.warn('legacy_block_access is deprecated and '
                           'will be removed from a future version please try the new mode',
@@ -1125,7 +1096,6 @@ class PythonExporter:
             legacy_block_access=legacy_block_access,
             udp_include_func=udp_include_func,
             hide_node_func=hide_node_func,
-            legacy_enum_type=legacy_enum_type,
             skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties,
             skip_systemrdl_name_and_desc_in_docstring=skip_systemrdl_name_and_desc_in_docstring,
             register_class_per_generated_file=register_class_per_generated_file,
@@ -1147,8 +1117,7 @@ class PythonExporter:
             # export the baseclasses for the tests
             self.__export_base_tests(top_block=top_block, package=package, asyncoutput=asyncoutput,
                                      skip_lib_copy=skip_library_copy,
-                                     legacy_block_access=legacy_block_access,
-                                     legacy_enum_type=legacy_enum_type)
+                                     legacy_block_access=legacy_block_access)
             # export the tests themselves, these are broken down to one file per addressmap
             self.__export_tests(
                 top_block=top_block, package=package, asyncoutput=asyncoutput,
@@ -1156,7 +1125,6 @@ class PythonExporter:
                 legacy_block_access=legacy_block_access,
                 udp_include_func=udp_include_func,
                 hide_node_func=hide_node_func,
-                legacy_enum_type=legacy_enum_type,
                 skip_systemrdl_name_and_desc_properties=skip_systemrdl_name_and_desc_properties)
 
         return top_block.inst_name

--- a/src/peakrdl_python/lib/base_field.py
+++ b/src/peakrdl_python/lib/base_field.py
@@ -19,7 +19,6 @@ This module is intended to distributed as part of automatically generated code b
 peakrdl-python tool. It provides the base types for fields that are shared by non-async and async
 fields
 """
-from enum import IntEnum
 from typing import cast, Optional, TypeVar, Generic
 from abc import ABC
 import warnings
@@ -156,7 +155,7 @@ class FieldMiscProps:
 
 
 # The following line should be:
-# FieldType = TypeVar('FieldType', bound=int|IntEnum|SystemRDLEnum)
+# FieldType = TypeVar('FieldType', bound=int|SystemRDLEnum)
 # However, python 3.9 does not support the combination so the binding was removed
 # pylint: disable-next=invalid-name
 FieldType = TypeVar('FieldType')
@@ -214,7 +213,7 @@ class Field(Generic[FieldType], Base, ABC):
 
         self.__bitmask = calculate_bitmask(high=self.high, low=self.low)
 
-        if not issubclass(field_type, (int, IntEnum, SystemRDLEnum)):
+        if not issubclass(field_type, (int, SystemRDLEnum)):
             raise TypeError(f'Unsupported field type: {field_type}')
         self.__field_type = field_type
 
@@ -340,7 +339,7 @@ class Field(Generic[FieldType], Base, ABC):
         - if the field is not reset.
         - if the register resets to a signal value that can not be determined
         """
-        if issubclass(self._field_type, (SystemRDLEnum, IntEnum)):
+        if issubclass(self._field_type, (SystemRDLEnum)):
             int_default = self.__misc_props.default
 
             if int_default is not None:
@@ -413,7 +412,7 @@ class _FieldReadOnlyFramework(Field[FieldType], ABC):
             return_int_value = swap_msb_lsb_ordering(value=(value & self.bitmask) >> self.low,
                                                  width=self.width)
 
-        if issubclass(self._field_type, (SystemRDLEnum, IntEnum)):
+        if issubclass(self._field_type, (SystemRDLEnum)):
             return self._field_type(return_int_value) # type: ignore[return-value]
         if issubclass(self._field_type, int):
             return return_int_value # type: ignore[return-value]
@@ -470,7 +469,7 @@ class _FieldWriteOnlyFramework(Field[FieldType], ABC):
             raise TypeError(f'Field type is not as expected, got {type(value)},'
                             f' expected {self._field_type}')
 
-        if isinstance(value, (SystemRDLEnum, IntEnum)):
+        if isinstance(value, (SystemRDLEnum)):
             int_value = value.value
         elif isinstance(value, int):
             int_value = value

--- a/src/peakrdl_python/templates/addrmap_simulation_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_simulation_tb.py.jinja
@@ -35,9 +35,8 @@ import unittest
 from unittest.mock import Mock
 {% endif %}
 import random
-{% if legacy_enum_type %}
 from enum import IntEnum
-{% endif %}
+
 
 from {{ peakrdl_python_sim_lib(depth=lib_depth) }}.register import Register,MemoryRegister
 from {{ peakrdl_python_sim_lib(depth=lib_depth) }}.field import ReadOnlyField, WriteOnlyField, ReadWriteField
@@ -46,9 +45,7 @@ from ._{{top_node.inst_name}}_sim_test_base import {{top_node.inst_name}}_SimTes
 from ._{{top_node.inst_name}}_sim_test_base import __name__ as base_name
 from ._{{top_node.inst_name}}_test_base import random_enum_reg_value
 
-{% if not legacy_enum_type %}
 from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum
-{% endif %}
 
 from {{ peakrdl_python_lib_test(depth=lib_depth) }} import reverse_bits
 

--- a/src/peakrdl_python/templates/addrmap_tb.py.jinja
+++ b/src/peakrdl_python/templates/addrmap_tb.py.jinja
@@ -36,9 +36,8 @@ from unittest.mock import patch, call
 import random
 from itertools import combinations, chain
 import math
-{% if legacy_enum_type %}
 from enum import IntEnum
-{% endif %}
+
 
 from {{ peakrdl_python_lib(depth=lib_depth) }} import UnsupportedWidthError
 
@@ -68,9 +67,8 @@ from {{ peakrdl_python_lib(depth=lib_depth) }} import Memory
 from {{ peakrdl_python_lib(depth=lib_depth) }} import NodeArray
 from {{ peakrdl_python_lib(depth=lib_depth) }} import Field
 from {{ peakrdl_python_lib(depth=lib_depth) }} import Reg
-{% if not legacy_enum_type %}
 from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum, SystemRDLEnumEntry
-{% endif %}
+
 from {{ peakrdl_python_lib_test(depth=lib_depth) }} import reverse_bits
 from {{ peakrdl_python_lib_test(depth=lib_depth) }} import NodeIterators
 
@@ -159,7 +157,7 @@ class {{fq_block_name}}_single_access({{top_node.inst_name}}_TestCase): # type: 
             {% if asyncoutput %}await {%endif %}self._single_int_field_read_and_write_test(fut=self.dut.{{'.'.join(get_python_path_segments(node))}}, is_sw_readable={{node.is_sw_readable}}, is_sw_writable={{node.is_sw_writable}})
             {%- else %}
             {% if asyncoutput %}await {%endif %}self._single_enum_field_read_and_write_test(fut=self.dut.{{'.'.join(get_python_path_segments(node))}}, # type: ignore[arg-type]
-                                                                                            is_sw_readable={{node.is_sw_readable}}, is_sw_writable={{node.is_sw_writable}}, full_enum_def={ {% for enum_entry in node.get_property('encode') %}'{{enum_entry.name.upper()}}':({{enum_entry.value}}, {% if enum_entry.rdl_name is none or legacy_enum_type or skip_systemrdl_name_and_desc_properties %}None{% else %}{{enum_entry.rdl_name | tojson}}{% endif %}, {% if enum_entry.rdl_desc is none or legacy_enum_type or skip_systemrdl_name_and_desc_properties %}None{% else %}{{enum_entry.rdl_desc | tojson}}{% endif %}),{% endfor %} })
+                                                                                            is_sw_readable={{node.is_sw_readable}}, is_sw_writable={{node.is_sw_writable}}, full_enum_def={ {% for enum_entry in node.get_property('encode') %}'{{enum_entry.name.upper()}}':({{enum_entry.value}}, {% if enum_entry.rdl_name is none or skip_systemrdl_name_and_desc_properties %}None{% else %}{{enum_entry.rdl_name | tojson}}{% endif %}, {% if enum_entry.rdl_desc is none or skip_systemrdl_name_and_desc_properties %}None{% else %}{{enum_entry.rdl_desc | tojson}}{% endif %}),{% endfor %} })
             {%- endif %}
         {%- endfor %}
 

--- a/src/peakrdl_python/templates/baseclass_tb.py.jinja
+++ b/src/peakrdl_python/templates/baseclass_tb.py.jinja
@@ -30,10 +30,6 @@ import asyncio
 {% endif %}
 import unittest
 import random
-{% if legacy_enum_type %}
-from enum import IntEnum
-{% endif %}
-
 
 from {{ peakrdl_python_lib(depth=lib_depth) }} import RegisterWriteVerifyError
 {% if asyncoutput %}
@@ -66,9 +62,8 @@ from {{ peakrdl_python_lib_test(depth=lib_depth) }} import LibTestBase as TestCa
 BlockTestBase = unittest.TestCase
 {% endif %}
 
-{% if not legacy_enum_type %}
 from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum, SystemRDLEnumEntry
-{% endif %}
+
 
 {% if asyncoutput %}async {% endif %}def read_callback(addr: int, width: int, accesswidth: int) -> int:
     return {% if asyncoutput %}await {% endif %}read_addr_space(addr=addr, width=width, accesswidth=accesswidth)
@@ -88,7 +83,7 @@ from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum, SystemRDLEn
 {% if asyncoutput %}async {%endif %}def write_block_callback_alt(addr: int, width: int, accesswidth: int,  data: {% if not legacy_block_access %}Array{% else %}list[int]{% endif %}) -> None:
     {% if asyncoutput %}await {% endif %}write_block_addr_space_alt(addr=addr, width=width, accesswidth=accesswidth, data=data)
 
-def random_enum_reg_value(enum_class: type[{% if legacy_enum_type %}IntEnum{% else %}SystemRDLEnum{% endif %}]) -> {% if legacy_enum_type %}IntEnum{% else %}SystemRDLEnum{% endif %}:
+def random_enum_reg_value(enum_class: type[SystemRDLEnum]) -> SystemRDLEnum:
     return random.choice(list(enum_class))
 
 

--- a/src/peakrdl_python/templates/field_enums.py.jinja
+++ b/src/peakrdl_python/templates/field_enums.py.jinja
@@ -21,23 +21,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% from 'template_ultilities.py.jinja' import peakrdl_python_lib with context %}
 {# the following defining the number relative steps up to the lib and sim_lib packages from the current file #}
 {% set lib_depth = 3 %}
-
-{% if legacy_enum_type %}
-from enum import IntEnum
-{% endif %}
 from enum import unique
 
-{% if not legacy_enum_type %}
 from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum, SystemRDLEnumEntry
-{% endif %}
 
 # root level enum definitions
 {%- for enum_needed in unique_enums %}
 @unique
-class {{enum_needed.python_class_name}}({% if legacy_enum_type %}IntEnum{% else %}SystemRDLEnum{% endif %}):
+class {{enum_needed.python_class_name}}(SystemRDLEnum):
 
     {% for value_of_enum_needed in enum_needed.instance -%}
-    {{ value_of_enum_needed.name.upper() }} = {% if legacy_enum_type %}{{ value_of_enum_needed.value }}{% else %}SystemRDLEnumEntry(int_value={{value_of_enum_needed.value}}, name={%- if value_of_enum_needed.rdl_name is not none and not skip_systemrdl_name_and_desc_properties -%}{{value_of_enum_needed.rdl_name | tojson}}{% else %}None{% endif %}, desc={%- if value_of_enum_needed.rdl_desc is not none and not skip_systemrdl_name_and_desc_properties -%}{{value_of_enum_needed.rdl_desc | tojson}}{% else %}None{% endif %}){% endif %}  {%- if value_of_enum_needed.rdl_desc is not none %}  # {{ value_of_enum_needed.rdl_desc }} {%- endif %}
+    {{ value_of_enum_needed.name.upper() }} = SystemRDLEnumEntry(int_value={{value_of_enum_needed.value}}, name={%- if value_of_enum_needed.rdl_name is not none and not skip_systemrdl_name_and_desc_properties -%}{{value_of_enum_needed.rdl_name | tojson}}{% else %}None{% endif %}, desc={%- if value_of_enum_needed.rdl_desc is not none and not skip_systemrdl_name_and_desc_properties -%}{{value_of_enum_needed.rdl_desc | tojson}}{% else %}None{% endif %}) {%- if value_of_enum_needed.rdl_desc is not none %}  # {{ value_of_enum_needed.rdl_desc }} {% endif %}
     {% endfor %}
 {% endfor -%}
 

--- a/src/peakrdl_python/templates/property_enums.py.jinja
+++ b/src/peakrdl_python/templates/property_enums.py.jinja
@@ -22,20 +22,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {# the following defining the number relative steps up to the lib and sim_lib packages from the current file #}
 {% set lib_depth = 1 %}
 
-{% if legacy_enum_type %}
-from enum import IntEnum
-{% endif %}
 from enum import unique
 
-{% if not legacy_enum_type %}
 from {{ peakrdl_python_lib(depth=lib_depth) }} import SystemRDLEnum, SystemRDLEnumEntry
-{% endif %}
 
 {% for property_enum in unique_property_enums %}
 @unique
-class {{property_enum.type_name}}_property_enumcls({% if legacy_enum_type %}IntEnum{% else %}SystemRDLEnum{% endif %}):
+class {{property_enum.type_name}}_property_enumcls(SystemRDLEnum):
     {% for value_of_enum_needed in property_enum -%}
-    {{ value_of_enum_needed.name.upper() }} = {% if legacy_enum_type %}{{ value_of_enum_needed.value }}{% else %}SystemRDLEnumEntry(int_value={{value_of_enum_needed.value}}, name={%- if value_of_enum_needed.rdl_name is not none -%}'{{value_of_enum_needed.rdl_name}}'{% else %}None{% endif %}, desc={%- if value_of_enum_needed.rdl_desc is not none -%}'{{value_of_enum_needed.rdl_desc}}'{% else %}None{% endif %}){% endif %}  {%- if value_of_enum_needed.rdl_desc is not none %}  # {{ value_of_enum_needed.rdl_desc }} {%- endif %}
+    {{ value_of_enum_needed.name.upper() }} = SystemRDLEnumEntry(int_value={{value_of_enum_needed.value}}, name={%- if value_of_enum_needed.rdl_name is not none -%}'{{value_of_enum_needed.rdl_name}}'{% else %}None{% endif %}, desc={%- if value_of_enum_needed.rdl_desc is not none -%}'{{value_of_enum_needed.rdl_desc}}'{% else %}None{% endif %})  {%- if value_of_enum_needed.rdl_desc is not none %}  # {{ value_of_enum_needed.rdl_desc }} {%- endif %}
     {% endfor %}
 {% endfor %}
 

--- a/tests/unit_tests/test_field.py
+++ b/tests/unit_tests/test_field.py
@@ -21,7 +21,6 @@ import unittest
 from typing import Optional, Union, TypeVar
 from collections.abc import Iterator
 from unittest.mock import patch, MagicMock
-from enum import IntEnum
 from itertools import product
 
 

--- a/tests/unit_tests/test_field.py
+++ b/tests/unit_tests/test_field.py
@@ -389,17 +389,17 @@ class TestField(CallBackTestWrapper):
         """
         Test are Read/Write Enumerated Field
         """
-        for enum_type, msb_high in product([IntEnum, SystemRDLEnum], [True, False]):
-            with self.subTest(test_case=f'{enum_type=}, {msb_high}'):
+        for msb_high in product([True, False]):
+            with self.subTest(test_case=f'{msb_high}'):
                 # pylint: disable-next=too-few-public-methods
-                class DUTEnumType(enum_type):
+                class DUTEnumType(SystemRDLEnum):
                     """
                     Enumeration to use in the test
                     """
-                    VALUE1 = 0x1 if enum_type is IntEnum else SystemRDLEnumEntry(0x1, None, None)
-                    VALUE2 = 0x2 if enum_type is IntEnum else SystemRDLEnumEntry(0x2, None, None)
-                    VALUE3 = 0x4 if enum_type is IntEnum else SystemRDLEnumEntry(0x3, None, None)
-                    VALUE4 = 0x8 if enum_type is IntEnum else SystemRDLEnumEntry(0x8, None, None)
+                    VALUE1 = SystemRDLEnumEntry(0x1, None, None)
+                    VALUE2 = SystemRDLEnumEntry(0x2, None, None)
+                    VALUE3 = SystemRDLEnumEntry(0x3, None, None)
+                    VALUE4 = SystemRDLEnumEntry(0x8, None, None)
 
                 for low in range(0, 4, 4):
                     dut = self.generate_dut(
@@ -464,19 +464,17 @@ class TestField(CallBackTestWrapper):
         """
         Test are Read Only Enumerated Field
         """
-        for enum_type, msb_high, register_type in product([IntEnum, SystemRDLEnum],
-                                                          [True, False],
-                                                          [RegReadWrite, RegReadOnly]):
-            with self.subTest(test_case=f'{enum_type=}, {msb_high}, {register_type=}'):
+        for msb_high, register_type in product([True, False], [RegReadWrite, RegReadOnly]):
+            with self.subTest(test_case=f'{msb_high}, {register_type=}'):
                 # pylint: disable-next=too-few-public-methods
-                class DUTEnumType(enum_type):
+                class DUTEnumType(SystemRDLEnum):
                     """
                     Enumeration to use in the test
                     """
-                    VALUE1 = 0x1 if enum_type is IntEnum else SystemRDLEnumEntry(0x1, None, None)
-                    VALUE2 = 0x2 if enum_type is IntEnum else SystemRDLEnumEntry(0x2, None, None)
-                    VALUE3 = 0x4 if enum_type is IntEnum else SystemRDLEnumEntry(0x3, None, None)
-                    VALUE4 = 0x8 if enum_type is IntEnum else SystemRDLEnumEntry(0x8, None, None)
+                    VALUE1 = SystemRDLEnumEntry(0x1, None, None)
+                    VALUE2 = SystemRDLEnumEntry(0x2, None, None)
+                    VALUE3 = SystemRDLEnumEntry(0x3, None, None)
+                    VALUE4 = SystemRDLEnumEntry(0x8, None, None)
 
                 for low in range(0, 4, 4):
                     dut = self.generate_dut(
@@ -515,19 +513,17 @@ class TestField(CallBackTestWrapper):
         """
         Test are Write Only Enumerated Field
         """
-        for enum_type, msb_high, register_type in product([IntEnum, SystemRDLEnum],
-                                                          [True, False],
-                                                          [RegReadWrite, RegWriteOnly]):
-            with self.subTest(test_case=f'{enum_type=}, {msb_high}, {register_type=}'):
+        for msb_high, register_type in product([True, False], [RegReadWrite, RegWriteOnly]):
+            with self.subTest(test_case=f'{msb_high}, {register_type=}'):
                 # pylint: disable-next=too-few-public-methods
-                class DUTEnumType(enum_type):
+                class DUTEnumType(SystemRDLEnum):
                     """
                     Enumeration to use in the test
                     """
-                    VALUE1 = 0x1 if enum_type is IntEnum else SystemRDLEnumEntry(0x1, None, None)
-                    VALUE2 = 0x2 if enum_type is IntEnum else SystemRDLEnumEntry(0x2, None, None)
-                    VALUE3 = 0x4 if enum_type is IntEnum else SystemRDLEnumEntry(0x3, None, None)
-                    VALUE4 = 0x8 if enum_type is IntEnum else SystemRDLEnumEntry(0x8, None, None)
+                    VALUE1 = SystemRDLEnumEntry(0x1, None, None)
+                    VALUE2 = SystemRDLEnumEntry(0x2, None, None)
+                    VALUE3 = SystemRDLEnumEntry(0x3, None, None)
+                    VALUE4 = SystemRDLEnumEntry(0x8, None, None)
 
                 for low in range(0, 4, 4):
                     dut = self.generate_dut(


### PR DESCRIPTION
Prior to version 1.2, enumerations were encoded with `IntEnum`, which meant the systemRDL `name` and `desc` did not get included. A new `SystemRDLEnum` was introduced to address that issue